### PR TITLE
Add explicit F- and R-symbol conventions

### DIFF
--- a/src/AnyonWiki/AnyonWiki.jl
+++ b/src/AnyonWiki/AnyonWiki.jl
@@ -130,15 +130,16 @@ function anyonwiki_center_artifact_path(i,j,k,l,m,n,o)
     end
 end
 
-function dict_to_associator(ass::Dict)
+function dict_to_associator(ass::Dict; convention::Symbol=:column_major_packing)
     isempty(ass) && throw(ArgumentError("an F-symbol dictionary must be nonempty"))
     # Every simple label appears among the four object indices, independently
     # of where the unit is listed or whether the first simple is invertible.
     N = maximum(maximum(k[1:4]) for k in keys(ass))
-    dict_to_associator(N, parent(first(ass)[2]), ass)
+    dict_to_associator(N, parent(first(ass)[2]), ass; convention)
 end
 
-function dict_to_associator(N::Int, K::Field, ass::Dict)
+function dict_to_associator(N::Int, K::Field, ass::Dict; convention::Symbol=:column_major_packing)
+    _check_symbol_convention(convention)
     # Transform associator dict to Matrices 
 
     ass_matrices = Array{MatElem,4}(undef,N,N,N,N)
@@ -150,20 +151,73 @@ function dict_to_associator(N::Int, K::Field, ass::Dict)
             ass_matrices[a,b,c,d] = zero_matrix(K,0,0)
             continue
         end
-        D = groups[[a,b,c,d]]
-        abc_d = collect(keys(D))
-        l = isqrt(length(abc_d))
-        l^2 == length(abc_d) || throw(ArgumentError("incomplete square F-symbol block"))
-        if length(first(keys(ass))) == 6 
-            abc_d = sort(abc_d, by = v -> v[[6,5]])
-        else
-            abc_d = sort(abc_d, by = v -> v[[8,5,10,9,7,6]])
-        end
-        M = matrix(K,l,l, [D[v] for v ∈ abc_d])
-        ass_matrices[a,b,c,d] = transpose(M)
+        ass_matrices[a,b,c,d] = _F_symbol_matrix(K, groups[[a,b,c,d]], convention)
     end
 
     ass_matrices 
+end
+
+# Oscar's matrix(K,n,n,entries) reads rows, whereas the historical symbol
+# dictionaries pack columns. Keep that decoding separate from fusion paths.
+function _F_symbol_matrix(K, D, convention)
+    ks = collect(keys(D))
+    n = isqrt(length(ks))
+    n^2 == length(ks) || throw(ArgumentError("incomplete square F-symbol block"))
+    isempty(ks) && return zero_matrix(K,0,0)
+    width = length(first(ks))
+    width in (6,10) && all(k -> length(k) == width, ks) ||
+        throw(ArgumentError("F-symbol labels must consistently have length 6 or 10"))
+    if convention == :column_major_packing
+        order = width == 6 ? [6,5] : [8,5,10,9,7,6]
+        sort!(ks; by=k -> k[order])
+        return transpose(matrix(K,n,n,[D[k] for k in ks]))
+    end
+    left(k) = width == 6 ? (k[5],1,1) : Tuple(k[5:7])
+    right(k) = width == 6 ? (k[6],1,1) : Tuple(k[8:10])
+    rows = sort!(unique(left.(ks)))
+    cols = sort!(unique(right.(ks)))
+    length(rows) == length(cols) == n ||
+        throw(ArgumentError("incomplete Cartesian block of fusion paths"))
+    ri = Dict(v => i for (i,v) in enumerate(rows))
+    ci = Dict(v => i for (i,v) in enumerate(cols))
+    A = zero_matrix(K,n,n)
+    for k in ks
+        A[ri[left(k)],ci[right(k)]] = D[k]
+    end
+    A
+end
+
+function _R_symbol_matrix(K, D, convention)
+    ks = sort!(collect(keys(D)))
+    n = isqrt(length(ks))
+    n^2 == length(ks) || throw(ArgumentError("incomplete square R-symbol block"))
+    isempty(ks) && return zero_matrix(K,0,0)
+    width = length(first(ks))
+    width in (3,5) && all(k -> length(k) == width, ks) ||
+        throw(ArgumentError("R-symbol labels must consistently have length 3 or 5"))
+    if width == 5
+        [k[4:5] for k in ks] == [[i,j] for i in 1:n for j in 1:n] ||
+            throw(ArgumentError("R-symbol basis indices must fill a square block starting at 1"))
+    end
+    A = matrix(K,n,n,[D[k] for k in ks])
+    convention == :column_major_packing ? transpose(A) : A
+end
+
+# Version 1 adds an explicit convention; older, untagged archives retain the
+# historical interpretation. Never infer a convention from matrix entries.
+function _symbol_file_convention(meta, requested)
+    requested === nothing || _check_symbol_convention(requested)
+    tagged = haskey(meta, "symbol_format_version") || haskey(meta, "symbol_convention")
+    if tagged
+        get(meta, "symbol_format_version", nothing) == 1 ||
+            throw(ArgumentError("unsupported symbol format version"))
+        haskey(meta, "symbol_convention") || throw(ArgumentError("missing symbol convention"))
+        stored = _check_symbol_convention(Symbol(meta["symbol_convention"]))
+        requested === nothing || requested == stored ||
+            throw(ArgumentError("requested convention conflicts with the file metadata"))
+        return stored
+    end
+    requested === nothing ? :column_major_packing : requested
 end
 
 function anyonwiki_keys(n::Int = 7, attrs::String...)
@@ -191,23 +245,19 @@ function group_dict_keys_by(f::Function, D::Dict)
     return groups 
 end
 
-function dict_to_braiding(ass::Dict)
+function dict_to_braiding(ass::Dict; convention::Symbol=:column_major_packing)
     isempty(ass) && throw(ArgumentError("an R-symbol dictionary must be nonempty"))
     N = maximum(maximum(k[1:3]) for k in keys(ass))
-    dict_to_braiding(N, parent(first(ass)[2]), ass)
+    dict_to_braiding(N, parent(first(ass)[2]), ass; convention)
 end
 
-function dict_to_braiding(N::Int, K::Field, braid::Dict)
-    # Transform associator dict to Matrices 
+function dict_to_braiding(N::Int, K::Field, braid::Dict; convention::Symbol=:column_major_packing)
+    _check_symbol_convention(convention)
+    groups = group_dict_keys_by(k -> k[1:3], braid)
     braiding_array = Array{MatElem,3}(undef,N,N,N)
-
-    for a ∈ 1:N, b ∈ 1:N, c ∈ 1:N
-        ab_c = filter(e -> e[[1,2,3]] == [a,b,c], collect(keys(braid)))
-        l = isqrt(length(ab_c))
-        l^2 == length(ab_c) || throw(ArgumentError("incomplete square R-symbol block"))
-        sort!(ab_c)
-        M = matrix(K,l,l, [braid[v] for v ∈ ab_c])
-        braiding_array[a,b,c] = transpose(M)
+    for a in 1:N, b in 1:N, c in 1:N
+        D = get(groups, [a,b,c], Dict())
+        braiding_array[a,b,c] = _R_symbol_matrix(K,D,convention)
     end
     braiding_array
 end
@@ -337,19 +387,29 @@ end
     Save to anyonwiki 
 ----------------------------------------------------------=#
 
-function save_fusion_category(C::SixJCategory, path::String, name::String)
+"""
+    save_fusion_category(C::SixJCategory, path, name; convention=:column_major_packing)
+
+Save exact F/R symbols in the chosen dictionary convention (see [`F_symbols`](@ref)
+and [`R_symbols`](@ref)), together with the field, pivotal structure and category
+metadata. New archives record format version 1 and the convention. Existing
+archives are not changed. This is the symbol archive format, not Oscar's native
+`save`/`load` serialization of structural matrices.
+"""
+function save_fusion_category(C::SixJCategory, path::String, name::String; convention::Symbol=:column_major_packing)
+    _check_symbol_convention(convention)
     cat_path = joinpath(path, name)
 
     mkdir(cat_path)
 
-    save_fusion_category_meta_data(C, joinpath(cat_path, "$(name)_meta"))
+    save_fusion_category_meta_data(C, joinpath(cat_path, "$(name)_meta"); convention)
 
-    save_symbols(F_symbols(C), joinpath(cat_path, "$(name)_F_symbols"), 4)
+    save_symbols(F_symbols(C; convention), joinpath(cat_path, "$(name)_F_symbols"), 4; convention)
 
     save_symbols(P_symbols(C), joinpath(cat_path, "$(name)_P_symbols"))
     
     if is_braided(C) 
-        save_symbols(R_symbols(C), joinpath(cat_path, "$(name)_R_symbols"))
+        save_symbols(R_symbols(C; convention), joinpath(cat_path, "$(name)_R_symbols"); convention)
     end
     return nothing
 end
@@ -361,11 +421,21 @@ function anyonwiki_center_meta(i,j,k,l,m,n,o)
     meta = include(joinpath(p, "$(name)_meta"))
 end
 
-function load_fusion_category(file::String)
+"""
+    load_fusion_category(file; convention=nothing)
+
+Load an exact symbol archive. By default use its recorded convention, or
+`:column_major_packing` for an older archive without convention metadata.
+An explicit convention declares the encoding of an untagged archive; it must
+agree with any metadata present. See [`save_fusion_category`](@ref).
+"""
+function load_fusion_category(file::String; convention::Union{Nothing,Symbol}=nothing)
     
     name = splitpath(file)[end]
 
     meta = include(joinpath(file, "$(name)_meta"))
+
+    convention = _symbol_file_convention(meta, convention)
 
     K = meta["field"]
     rank = meta["rank"]
@@ -374,7 +444,7 @@ function load_fusion_category(file::String)
     one = meta["one"]
 
     # include F/P/R-symbols as coefficient vectors, convert to number field elements and then to matrices
-    F_symbols = load_F_symbols(rank,K,joinpath(file, "$(name)_F_symbols"))
+    F_symbols = load_F_symbols(rank,K,joinpath(file, "$(name)_F_symbols"); convention)
 
     P_symbols = include(joinpath(file, "$(name)_P_symbols"))
     P_symbols = [K == QQ ? K(P_symbols[k]...) : K(P_symbols[k]) for k ∈ sort(collect(keys(P_symbols)))]
@@ -393,7 +463,7 @@ function load_fusion_category(file::String)
     end
     
     if isfile(joinpath(file, "$(name)_R_symbols"))
-        R_symbols = load_R_symbols(rank,K,joinpath(file, "$(name)_R_symbols"))
+        R_symbols = load_R_symbols(rank,K,joinpath(file, "$(name)_R_symbols"); convention)
         set_braiding!(C, R_symbols)
     end
 
@@ -429,51 +499,54 @@ function anyonwiki_center_grothendieck_ring(i,j,k,l,m,n,o)
 end
 
 
-function load_F_symbols(rank::Int, K::Field, path::String)
-    ass = Array{MatElem,4}(undef, rank,rank,rank,rank)
+"""
+    load_F_symbols(rank, K, path; convention=:column_major_packing)
 
-    for i ∈ 1:rank, j ∈ 1:rank, k ∈ 1:rank, l ∈ 1:rank 
-        _file = joinpath(path, "[$(i), $(j), $(k), $l]")
-
-        if isfile(_file)
-            symbols = include(_file)
-            symbols_keys = collect(keys(symbols))
-            if length(first(keys(symbols))) == 6 
-                symbols_keys = sort(symbols_keys, by = v -> v[[6,5]])
-            else
-               symbols_keys = sort(symbols_keys, by = v -> v[[8,5,10,9,7,6]])
-            end
-            n = Int(sqrt(length(symbols_keys)))
-            vals = [K == QQ ? K(symbols[v]...) : K(symbols[v]) for v ∈ symbols_keys]
-            M = matrix(K,n,n, vals)
-            ass[i,j,k,l] = transpose(M)
+Decode a directory of exact coefficient dictionaries into associator matrices.
+Unlike `load_fusion_category`, this low-level reader has no category metadata;
+`convention` must describe the supplied dictionaries.
+"""
+function load_F_symbols(rank::Int, K::Field, path::String; convention::Symbol=:column_major_packing)
+    _check_symbol_convention(convention)
+    ass = Array{MatElem,4}(undef,rank,rank,rank,rank)
+    for i in 1:rank, j in 1:rank, k in 1:rank, l in 1:rank
+        file = joinpath(path, "[$i, $j, $k, $l]")
+        if isfile(file)
+            data = include(file)
+            D = Dict(key => (K == QQ ? K(v...) : K(v)) for (key,v) in data)
+            ass[i,j,k,l] = _F_symbol_matrix(K,D,convention)
         else
             ass[i,j,k,l] = zero_matrix(K,0,0)
         end
     end
-    ass 
+    ass
 end
 
-function load_R_symbols(rank::Int, K::Field, path::String)
-    braid = [zero_matrix(K,0,0) for _ ∈ 1:rank, _ ∈ 1:rank, _ ∈ 1:rank]
-    symbols = include(path)
-    chunks = group_dict_keys_by(e -> e[1:3], symbols)
+"""
+    load_R_symbols(rank, K, path; convention=:column_major_packing)
 
-    for ((i,j,k), D) ∈ chunks 
-        
-        symbols_keys = sort(collect(keys(D)))
-        n = Int(sqrt(length(D)))
-        vals = [K == QQ ? K(D[v]...) : K(D[v]) for v ∈ symbols_keys]
-
-        M = matrix(K,n,n, vals)
-        braid[i,j,k] = transpose(M)
-    end
-    braid 
+Decode an exact coefficient dictionary into braiding matrices. Supply the
+encoding explicitly when reading nondefault data without category metadata.
+"""
+function load_R_symbols(rank::Int, K::Field, path::String; convention::Symbol=:column_major_packing)
+    data = include(path)
+    D = Dict(key => (K == QQ ? K(v...) : K(v)) for (key,v) in data)
+    dict_to_braiding(rank,K,D; convention)
 end
 
 
 
-function save_symbols(S::Dict, path::String, chunk::Int = 0)
+"""
+    save_symbols(S::Dict, path, chunk=0; convention=:column_major_packing)
+
+Write an already encoded dictionary as exact coefficient vectors. As for
+`numeric_symbols_to_csv`, the keyword declares the supplied encoding and does
+not convert it. Nondefault files carry a comment identifying the convention;
+low-level readers still require it explicitly. Use `save_fusion_category` for
+category metadata and automatic convention selection on loading.
+"""
+function save_symbols(S::Dict, path::String, chunk::Int = 0; convention::Symbol=:column_major_packing)
+    _check_symbol_convention(convention)
     K = parent(first(S)[2])
 
     if chunk != 0
@@ -482,6 +555,7 @@ function save_symbols(S::Dict, path::String, chunk::Int = 0)
 
         for (k,ch) ∈ chunks
             open(joinpath(path, "$k"), "w") do io 
+                convention == :column_major_packing || write(io,"# symbol_convention=$convention\n")
                 write(io, "Dict(\n")
                 
                 if K == QQ
@@ -495,6 +569,7 @@ function save_symbols(S::Dict, path::String, chunk::Int = 0)
         end
     else
         open(path, "w") do io 
+            convention == :column_major_packing || write(io,"# symbol_convention=$convention\n")
             write(io, "Dict(\n")
             
             if K == QQ
@@ -508,11 +583,14 @@ function save_symbols(S::Dict, path::String, chunk::Int = 0)
     end
 end
 
-function save_fusion_category_meta_data(C::SixJCategory, file::String)
+function save_fusion_category_meta_data(C::SixJCategory, file::String; convention::Symbol=:column_major_packing)
+    _check_symbol_convention(convention)
     open(file, "w") do io 
         write(io, "# Meta data for $C\n\n")
         write(io, """Dict(\n
         \t\"name\" => \"$(C.name)\",\n""")
+        write(io, "\t\"symbol_format_version\" => 1,\n")
+        write(io, "\t\"symbol_convention\" => :$convention,\n")
         if base_ring(C) == QQ 
             write(io, "\t\"field\" => QQ,\n")
         else

--- a/src/Serialization/symbols_to_csv.jl
+++ b/src/Serialization/symbols_to_csv.jl
@@ -2,8 +2,21 @@
     Save F- and R-symbols as a readable csv file
 ----------------------------------------------------------=#
 
-function numeric_symbols_to_csv(destination::String, F::Dict{Vector{Int}, AcbFieldElem}; delimiter = ", ")
-    open(destination, "w") do io 
+"""
+    numeric_symbols_to_csv(destination, symbols; delimiter=", ", convention=:column_major_packing)
+
+Write a numerical F- or R-symbol dictionary. `convention` declares its existing
+encoding; it does not convert the supplied plain dictionary. Obtain it with the
+same keyword on `numeric_F_symbols` or `numeric_R_symbols`. Default output keeps
+the historical headerless CSV format. Nondefault output includes a convention
+header, which `load_numeric_fusion_category` reads automatically.
+"""
+function numeric_symbols_to_csv(destination::String, F::Dict{Vector{Int}, AcbFieldElem}; delimiter = ", ", convention::Symbol=:column_major_packing)
+    _check_symbol_convention(convention)
+    open(destination, "w") do io
+        if convention != :column_major_packing
+            write(io, "# TensorCategories symbol_format_version=1 symbol_convention=$convention\n")
+        end
         # CSV rows are ordered by symbol indices, independently of Dict order.
         sorted = sort!(collect(F); by = first)
 
@@ -21,27 +34,45 @@ function numeric_symbols_to_csv(destination::String, F::Dict{Vector{Int}, AcbFie
     end
 end
 
-function numeric_symbols_from_csv(file::String, K::Field = AcbField(64); delimiter = ", ")
-    F = Dict{Vector{Int}, elem_type(K)}()
+"""
+    numeric_symbols_from_csv(file, K=AcbField(64); delimiter=", ", convention=nothing)
 
-    lines = readlines(file) 
-    
-    for l ∈ lines 
-        chunks = split(l, delimiter)
-        index = parse.(Int, chunks[1:end-2])
+Read a plain dictionary without changing its encoding. `convention` optionally
+checks a file header or declares the encoding of headerless data (historically
+`:column_major_packing`). The returned dictionary carries no convention tag.
+"""
+function numeric_symbols_from_csv(file::String, K::Field=AcbField(64);
+        delimiter=", ", convention::Union{Nothing,Symbol}=nothing)
+    first(_read_numeric_symbols(file,K; delimiter,convention))
+end
 
-        real,imag = K.(chunks[end-1:end])
-
-        push!(F, index => real + imag*K(im))
+function _read_numeric_symbols(file, K; delimiter, convention)
+    F = Dict{Vector{Int},elem_type(K)}()
+    lines = readlines(file)
+    meta = Dict{String,Any}()
+    if !isempty(lines) && startswith(first(lines), "# TensorCategories ")
+        header = popfirst!(lines)
+        m = match(r"^# TensorCategories symbol_format_version=(\d+) symbol_convention=(\w+)$",header)
+        m === nothing && throw(ArgumentError("invalid symbol convention header"))
+        meta["symbol_format_version"] = parse(Int,m[1])
+        meta["symbol_convention"] = Symbol(m[2])
     end
-    return F 
+    selected = _symbol_file_convention(meta,convention)
+    for line in lines
+        chunks = split(line,delimiter)
+        index = parse.(Int,chunks[1:end-2])
+        re,impart = K.(chunks[end-1:end])
+        F[index] = re + impart*K(im)
+    end
+    F,selected
 end
 
 # Recover binary multiplicities from the COMPLETE admissible fusion-path
 # labels, including zero matrix entries. Unlike a unit slice, this is invariant
 # under relabeling. EGNO §§4.6,4.9: the two bases of Hom((ab)c,d) are indexed
 # by intermediate simples and bases in their binary multiplicity spaces.
-function _fusion_rules_from_symbol_dictionary(F::Dict; check::Bool=false)
+function _fusion_rules_from_symbol_dictionary(F::Dict; check::Bool=false, convention::Symbol=:column_major_packing)
+    _check_symbol_convention(convention)
     isempty(F) && throw(ArgumentError("an F-symbol dictionary must be nonempty"))
     width = length(first(keys(F)))
     width in (6,10) || throw(ArgumentError("F-symbol labels must have length 6 or 10"))
@@ -54,10 +85,14 @@ function _fusion_rules_from_symbol_dictionary(F::Dict; check::Bool=false)
         a,b,c,d = key[1:4]
         labels = (a,b,c,d)
         check && (counts[labels] = get(counts,labels,0)+1)
-        f,e = key[5],key[width == 6 ? 6 : 8]
+        if convention == :bonderson
+            e,f = key[5],key[width == 6 ? 6 : 8]
+            j,i,i2,j2 = width == 6 ? (1,1,1,1) : (key[6],key[7],key[9],key[10])
+        else
+            f,e = key[5],key[width == 6 ? 6 : 8]
+            j,i,i2,j2 = width == 6 ? (1,1,1,1) : (key[9],key[10],key[7],key[6])
+        end
         max(e,f) <= n || throw(ArgumentError("fusion-channel label outside the object range"))
-        # Ten-index convention: [a,b,c,d,f,j2,i2,e,j,i].
-        j,i,i2,j2 = width == 6 ? (1,1,1,1) : (key[9],key[10],key[7],key[6])
         for (x,y,z,m) in ((a,b,e,j),(e,c,d,i),(b,c,f,i2),(a,f,d,j2))
             N[x,y,z] = max(N[x,y,z],m)
         end
@@ -66,15 +101,15 @@ function _fusion_rules_from_symbol_dictionary(F::Dict; check::Bool=false)
 end
 
 function _load_numeric_fusion_category(F::Dict, R, K; transpose=false,
-        unit=nothing, pivotal=nothing, check::Bool=false)
-    N,counts = _fusion_rules_from_symbol_dictionary(F;check)
+        unit=nothing, pivotal=nothing, check::Bool=false, convention::Symbol=:column_major_packing)
+    N,counts = _fusion_rules_from_symbol_dictionary(F;check,convention)
     n = size(N,1)
     identity = [Int(i == j) for i in 1:n,j in 1:n]
     units = [u for u in 1:n if N[u,:,:] == identity && N[:,u,:] == identity]
     length(units) == 1 || throw(ArgumentError("F-symbols must specify a unique simple tensor unit"))
     u = only(units)
     unit === nothing || unit == u || throw(ArgumentError("specified unit disagrees with the fusion paths"))
-    ass = dict_to_associator(n,K,F)
+    ass = dict_to_associator(n,K,F; convention)
     if check
         for a in 1:n,b in 1:n,c in 1:n,d in 1:n
             rows = sum(N[a,b,e]*N[e,c,d] for e in 1:n)
@@ -89,7 +124,7 @@ function _load_numeric_fusion_category(F::Dict, R, K; transpose=false,
     set_associator!(C,transpose ? Oscar.transpose.(ass) : ass)
     set_one!(C,u;check)
     if R !== nothing
-        braid = dict_to_braiding(n,K,R)
+        braid = dict_to_braiding(n,K,R; convention)
         if check
             for i in 1:n,j in 1:n,k in 1:n
                 size(braid[i,j,k]) == (N[i,j,k],N[j,i,k]) ||
@@ -119,20 +154,27 @@ maps: supply `pivotal` explicitly, or retain the constructor's unchecked all-one
 components. No canonical spherical structure or exact coherence is asserted.
 Pass `check=true` to validate completeness (including stored zero entries) and
 structural block dimensions; supplied dictionaries are trusted by default.
+
+`convention=nothing` uses the CSV header, with `:column_major_packing` as the
+fallback for historical headerless files. An explicit convention declares the
+encoding of headerless input and must agree with any header. F and R files must
+use the same convention. `transpose=true` is the historical, separate operation
+of transposing structural matrices *after* decoding; it is not a convention name.
 """
 function load_numeric_fusion_category(F::String, K::AcbField=AcbField(64);
         delimiter=", ", transpose=false, unit=nothing, pivotal=nothing,
-        check::Bool=false)
-    data = numeric_symbols_from_csv(F,K;delimiter=delimiter)
-    _load_numeric_fusion_category(data,nothing,K;transpose,unit,pivotal,check)
+        check::Bool=false, convention::Union{Nothing,Symbol}=nothing)
+    data,selected = _read_numeric_symbols(F,K;delimiter,convention)
+    _load_numeric_fusion_category(data,nothing,K;transpose,unit,pivotal,check,convention=selected)
 end
 
 function load_numeric_fusion_category(F::String, R::String, K::AcbField=AcbField(64);
         delimiter=", ", transpose=false, unit=nothing, pivotal=nothing,
-        check::Bool=false)
-    data = numeric_symbols_from_csv(F,K;delimiter=delimiter)
-    braid = numeric_symbols_from_csv(R,K;delimiter=delimiter)
-    _load_numeric_fusion_category(data,braid,K;transpose,unit,pivotal,check)
+        check::Bool=false, convention::Union{Nothing,Symbol}=nothing)
+    data,fc = _read_numeric_symbols(F,K;delimiter,convention)
+    braid,rc = _read_numeric_symbols(R,K;delimiter,convention)
+    fc == rc || throw(ArgumentError("F and R files use different symbol conventions"))
+    _load_numeric_fusion_category(data,braid,K;transpose,unit,pivotal,check,convention=fc)
 end
 
 # Preserve the previous positional delimiter/transpose overloads.

--- a/src/TensorCategoryFramework/SixJCategory/FusionCategory.jl
+++ b/src/TensorCategoryFramework/SixJCategory/FusionCategory.jl
@@ -1810,13 +1810,48 @@ end
     Export F-symbols as Dict 
 ----------------------------------------------------------=#
 
-@doc raw""" 
+# Dictionary conventions change coordinates at the API boundary, never the
+# associator/braiding matrices, fusion bases, or the category itself.
+function _check_symbol_convention(convention::Symbol)
+    convention in (:column_major_packing, :bonderson) ||
+        throw(ArgumentError("unknown symbol convention $convention; use :column_major_packing or :bonderson"))
+    convention
+end
 
-    F_symbols(C::SixJCategory)
+@doc raw"""
+    F_symbols(C::SixJCategory; convention=:column_major_packing)
 
-Return a Dictionary of the F-symbols of ``C``.
+Return a dictionary containing all F-symbol entries, including zeros.
+
+* `:bonderson`: keys are `[a,b,c,d,e,f]` in a multiplicity-free category,
+  otherwise `[a,b,c,d,e,μ,ν,f,ρ,σ]`. The left fusion path is
+  ``a b \xrightarrow{\mu} e,\ e c \xrightarrow{\nu} d``;
+  the right path is ``b c \xrightarrow{\rho} f,\ a f \xrightarrow{\sigma} d``.
+  Writing ``L_u`` and ``R_v`` for these projection trees and
+  ``\alpha:(a\otimes b)\otimes c\to a\otimes(b\otimes c)``, the entry is
+  ``A_{u v}`` in ``R_v\circ\alpha=\sum_u A_{u v}L_u``.
+  Equivalently, in composition-dual splitting bases,
+  ``\alpha\circ L^u=\sum_v A_{u v}R^v``. These are the coefficients of
+  Bonderson, *Non-Abelian Anyons and Interferometry* (2007), Eq. (2.6), p. 14,
+  https://thesis.caltech.edu/2447/02/thesis.pdf.
+  Rows of the stored matrix are ordered `(e,μ,ν)`, columns `(f,ρ,σ)`,
+  with the last index varying fastest.
+* `:column_major_packing` (default): preserves the historical dictionary
+  layout. In each `(a,b,c,d)` block, consume the stored matrix down columns
+  while traversing keys `[a,b,c,d,f,e]` in `(e,f)` order, or keys
+  `[a,b,c,d,f,σ,ρ,e,μ,ν]` in `(e,f,ν,μ,ρ,σ)` order. These key positions
+  do not, in general, label the matrix entry's fusion paths. Conversion
+  requires unpacking the block; a fixed permutation of key positions is
+  insufficient.
+
+The result is a plain `Dict`: it does not record its convention. Keep track of
+it when passing dictionaries to other functions. Neither choice changes gauge,
+inverts the associator, nor changes the internal matrices. These coordinates
+use the split skeletal bases of `SixJCategory`.
 """
-function F_symbols(C::SixJCategory)
+function F_symbols(C::SixJCategory; convention::Symbol=:column_major_packing)
+    _check_symbol_convention(convention)
+    convention == :bonderson && return _bonderson_F_symbols(C)
 
     S = simples(C)
 
@@ -1881,15 +1916,37 @@ function F_symbols(C::SixJCategory)
     return F_dict           
 end 
 
+function _bonderson_F_symbols(C::SixJCategory)
+    N = multiplication_table(C)
+    n = rank(C)
+    mf = multiplicity(C) == 1
+    F = Dict{Vector{Int},elem_type(base_ring(C))}()
+    for a in 1:n, b in 1:n, c in 1:n, d in 1:n
+        A = six_j_symbol(C,a,b,c,d)
+        row = 0
+        for e in 1:n, μ in 1:N[a,b,e], ν in 1:N[e,c,d]
+            row += 1
+            col = 0
+            for f in 1:n, ρ in 1:N[b,c,f], σ in 1:N[a,f,d]
+                col += 1
+                key = mf ? [a,b,c,d,e,f] : [a,b,c,d,e,μ,ν,f,ρ,σ]
+                F[key] = A[row,col]
+            end
+        end
+    end
+    F
+end
+
 @doc raw""" 
 
-    numeric_F_symbols(C::SixJCategory; precision = 128)
-    numeric_F_symbols(C::SixJCategory, e::AbsSimpleNumFieldEmbedding; precision = 128)
+    numeric_F_symbols(C::SixJCategory; precision=128, convention=:column_major_packing)
+    numeric_F_symbols(C::SixJCategory, e::AbsSimpleNumFieldEmbedding; precision=128, convention=:column_major_packing)
 
-Return a Dictionary of the F-symbols of ``C`` evaluated under the embedding ``e``. 
+Return [`F_symbols`](@ref) evaluated under the embedding ``e``. The keyword
+`convention=:column_major_packing` has the same meaning as for `F_symbols`.
 """
-function numeric_F_symbols(C::SixJCategory, e::AbsSimpleNumFieldEmbedding; precision = 128)
-    F = F_symbols(C)
+function numeric_F_symbols(C::SixJCategory, e::AbsSimpleNumFieldEmbedding; precision = 128, convention::Symbol=:column_major_packing)
+    F = F_symbols(C; convention)
 
     if base_ring(C) == QQ 
         return Dict(k => e(number_field(e)(v), precision) for (k,v) ∈ F)
@@ -1898,18 +1955,45 @@ function numeric_F_symbols(C::SixJCategory, e::AbsSimpleNumFieldEmbedding; preci
     end
 end
 
-function numeric_F_symbols(C::SixJCategory; precision = 128)
+function numeric_F_symbols(C::SixJCategory; precision = 128, convention::Symbol=:column_major_packing)
     !isdefined(C, :embedding) && error("No embedding has been specified")
-    numeric_F_symbols(C, getfield(C, :embedding), precision = precision)
+    numeric_F_symbols(C, getfield(C, :embedding); precision, convention)
 end
 
-@doc raw""" 
+@doc raw"""
+    R_symbols(C::SixJCategory; convention=:column_major_packing)
 
-    R_symbols(C::SixJCategory)
+Return all R-symbol entries, including zeros. In a multiplicity-free category,
+keys are `[a,b,c]` and both conventions agree. Otherwise keys are `[a,b,c,μ,ν]`.
 
-Return a Dictionary of the R-symbols of ``C``.
+For `:bonderson`, the value is ``B_{\mu\nu}`` defined by
+``p^{ba}_{c,\nu}\circ c_{a,b}=\sum_\mu B_{\mu\nu}p^{ab}_{c,\mu}``,
+where ``p`` are the fixed projection bases and ``c_{a,b}:a\otimes b\to b\otimes a``
+is the braiding. Equivalently, on composition-dual splitting bases,
+``c_{a,b}\circ s_{ab}^\mu=\sum_\nu B_{\mu\nu}s_{ba}^\nu``.
+Thus the input basis index comes first, as in Bonderson,
+*Non-Abelian Anyons and Interferometry* (2007), Eq. (2.54), p. 25,
+https://thesis.caltech.edu/2447/02/thesis.pdf.
+
+The default `:column_major_packing` preserves the historical dictionary:
+the same key has value ``B_{\nu\mu}``. This is a transpose of the two
+multiplicity indices, **not** the inverse braiding or a change of gauge.
+As with [`F_symbols`](@ref), the plain dictionary does not record its convention.
 """
-function R_symbols(C::SixJCategory)
+function R_symbols(C::SixJCategory; convention::Symbol=:column_major_packing)
+    _check_symbol_convention(convention)
+    if convention == :bonderson
+        N = multiplication_table(C)
+        mf = multiplicity(C) == 1
+        R = Dict{Vector{Int},elem_type(base_ring(C))}()
+        for a in 1:rank(C), b in 1:rank(C), c in 1:rank(C)
+            B = r_symbol(C,a,b,c)
+            for μ in 1:N[a,b,c], ν in 1:N[b,a,c]
+                R[mf ? [a,b,c] : [a,b,c,μ,ν]] = B[μ,ν]
+            end
+        end
+        return R
+    end
 
     S = simples(C)
 
@@ -1957,20 +2041,21 @@ end
 
 @doc raw""" 
 
-    numeric_R_symbols(C::SixJCategory; precision = 2048)
-    numeric_R_symbols(C::SixJCategory, e::AbsSimpleNumFieldEmbedding; precision = 2048)
+    numeric_R_symbols(C::SixJCategory; precision=2048, convention=:column_major_packing)
+    numeric_R_symbols(C::SixJCategory, e::AbsSimpleNumFieldEmbedding; precision=2048, convention=:column_major_packing)
 
-Return a Dictionary of the R-symbols of ``C`` evaluated under the embedding ``e``.
+Return [`R_symbols`](@ref) evaluated under the embedding ``e``. The keyword
+`convention=:column_major_packing` has the same meaning as for `R_symbols`.
 """
-function numeric_R_symbols(C::SixJCategory, e::AbsSimpleNumFieldEmbedding; precision = 2048)
-    R = R_symbols(C)
+function numeric_R_symbols(C::SixJCategory, e::AbsSimpleNumFieldEmbedding; precision = 2048, convention::Symbol=:column_major_packing)
+    R = R_symbols(C; convention)
 
-    Dict(k => e(v, precision) for (k,v) ∈ R)
+    Dict(k => e(base_ring(C) == QQ ? number_field(e)(v) : v, precision) for (k,v) ∈ R)
 end
 
-function numeric_R_symbols(C::SixJCategory; precision = 2048)
+function numeric_R_symbols(C::SixJCategory; precision = 2048, convention::Symbol=:column_major_packing)
     !isdefined(C, :embedding) && error("No embedding has been specified")
-    numeric_R_symbols(C, getfield(C, :embedding), precision = precision)
+    numeric_R_symbols(C, getfield(C, :embedding); precision, convention)
 end
 
 @doc raw""" 

--- a/src/TensorCategoryFramework/Skeletonization.jl
+++ b/src/TensorCategoryFramework/Skeletonization.jl
@@ -530,37 +530,42 @@ end
     Export Skeletal categories as dicts 
 ----------------------------------------------------------=#
 
-function save_F_symbols(C::SixJCategory, file::String)  
+"""
+    save_F_symbols(C::SixJCategory, file; convention=:column_major_packing)
 
-    F = F_symbols(C)
-    S,T = typeof(F).parameters
-    pol = polynomial(QQ,collect(coefficients(base_ring(C).pol)))
-
-    open(file, "w") do io
-        write(io, "# Field with defining polynomial $pol \n# relative to the basis 1,...,x^$(degree(pol)-1)\n\n ")
-
-        write(io,"Dict{$S,$T}(")
-
-        write(io, join(["\t$k => $(coefficients(v))" for (k,v) in F], ",\n"))
-
-        write(io, "\n)")
-    end
-    nothing
+Write exact F-symbols as a Julia dictionary of field-coefficient vectors, with
+comments identifying the field and convention. The keyword is forwarded to
+[`F_symbols`](@ref). `include(file)` returns coefficient vectors, not field
+elements; use `save_fusion_category` for a self-contained, loadable category.
+"""
+function save_F_symbols(C::SixJCategory, file::String; convention::Symbol=:column_major_packing)
+    _save_exact_symbol_dictionary(F_symbols(C; convention),file,convention)
 end
 
-function save_R_symbols(C::SixJCategory, file::String)  
+"""
+    save_R_symbols(C::SixJCategory, file; convention=:column_major_packing)
 
-    R = R_symbols(C)
-    S,T = typeof(R).parameters
-    pol = polynomial(QQ,collect(coefficients(base_ring(C).pol)))
+Write exact R-symbol coefficient vectors as for [`save_F_symbols`](@ref),
+forwarding `convention` to [`R_symbols`](@ref).
+"""
+function save_R_symbols(C::SixJCategory, file::String; convention::Symbol=:column_major_packing)
+    _save_exact_symbol_dictionary(R_symbols(C; convention),file,convention)
+end
 
-    open(file, "w") do io
-        write(io, "# Field with defining polynomial $pol \n# relative to the basis 1,...,x^$(degree(pol)-1)\n\n ")
-        write(io,"Dict{$S,$T}(")
-
-        write(io, join(["\t$k => $(coefficients(v))" for (k,v) in R], ",\n"))
-
-        write(io, "\n)")
+function _save_exact_symbol_dictionary(D, file, convention)
+    K = parent(first(values(D)))
+    open(file,"w") do io
+        if K == QQ
+            write(io,"# Field: QQ; coefficients are singleton rational vectors\n")
+        else
+            pol = polynomial(QQ,collect(coefficients(K.pol)))
+            write(io,"# Field with defining polynomial $pol\n# Relative to the basis 1,...,x^$(degree(pol)-1)\n")
+        end
+        write(io,"# symbol_format_version=1 symbol_convention=$convention\nDict(\n")
+        # Coefficient vectors must not be annotated with the field-element type.
+        entries = sort!(collect(D);by=first)
+        write(io,join(["\t$k => $(K == QQ ? [v] : collect(coefficients(v)))" for (k,v) in entries],",\n"))
+        write(io,"\n)\n")
     end
     nothing
 end

--- a/test/SixJCategoryTests/SymbolConventionSerialization.jl
+++ b/test/SixJCategoryTests/SymbolConventionSerialization.jl
@@ -1,0 +1,151 @@
+function same_matrices(C,D; numerical=false)
+    N = multiplication_table(C)
+    @test multiplication_table(D) == N
+    for I in CartesianIndices(C.ass)
+        A,B = TC.six_j_symbol(C,Tuple(I)...),TC.six_j_symbol(D,Tuple(I)...)
+        @test size(A) == size(B)
+        if numerical
+            @test all(overlaps(A[i,j],B[i,j]) for i in 1:nrows(A),j in 1:ncols(A))
+        else
+            @test A == B
+        end
+    end
+    for I in CartesianIndices(C.braiding)
+        A,B = TC.r_symbol(C,Tuple(I)...),TC.r_symbol(D,Tuple(I)...)
+        @test size(A) == size(B)
+        if numerical
+            @test all(overlaps(A[i,j],B[i,j]) for i in 1:nrows(A),j in 1:ncols(A))
+        else
+            @test A == B
+        end
+    end
+end
+
+@testset "F/R symbol files and numerical conventions" begin
+    for C in (anyonwiki(3,1,0,1,1,1,1),pointed_fixture())
+        K = base_ring(C)
+        emb = K == QQ ? complex_embedding(rationals_as_number_field()[1],1) : getfield(C,:embedding)
+        setfield!(C,:embedding,emb)
+        for convention in (:column_major_packing,:bonderson)
+            F = F_symbols(C;convention)
+            R = R_symbols(C;convention)
+            Fn = numeric_F_symbols(C;convention,precision=128)
+            Rn = numeric_R_symbols(C;convention,precision=128)
+            @test keys(Fn) == keys(F) && keys(Rn) == keys(R)
+            @test all(overlaps(v,emb(K == QQ ? number_field(emb)(F[k]) : F[k],128)) for (k,v) in Fn)
+            @test all(overlaps(v,emb(K == QQ ? number_field(emb)(R[k]) : R[k],128)) for (k,v) in Rn)
+            Fn_explicit = numeric_F_symbols(C,emb;convention,precision=128)
+            Rn_explicit = numeric_R_symbols(C,emb;convention,precision=128)
+            @test all(overlaps(v,Fn_explicit[k]) for (k,v) in Fn)
+            @test all(overlaps(v,Rn_explicit[k]) for (k,v) in Rn)
+            mktempdir() do dir
+                save_fusion_category(C,dir,"category";convention)
+                path = joinpath(dir,"category")
+                meta_file = joinpath(path,"category_meta")
+                metadata = include(meta_file)
+                @test metadata["symbol_convention"] == convention
+                @test metadata["symbol_format_version"] == 1
+                D = load_fusion_category(path)
+                # Reconstruct exact field elements in C's field, independently
+                # of the number-field parent newly constructed by the loader.
+                DF = F_symbols(D;convention=:bonderson)
+                DR = R_symbols(D;convention=:bonderson)
+                coerce(v) = K == QQ ? K(v) : K(collect(coefficients(v)))
+                @test Dict(k=>coerce(v) for (k,v) in DF) == F_symbols(C;convention=:bonderson)
+                @test Dict(k=>coerce(v) for (k,v) in DR) == R_symbols(C;convention=:bonderson)
+                @test D.one == C.one && simples_names(D) == simples_names(C)
+                @test coerce.(D.pivotal) == C.pivotal
+                other = convention == :bonderson ? :column_major_packing : :bonderson
+                @test_throws ArgumentError load_fusion_category(path;convention=other)
+                @test_throws ArgumentError load_fusion_category(path;convention=:unknown)
+                text = read(meta_file,String)
+                write(meta_file,replace(text,"\"symbol_format_version\" => 1"=>"\"symbol_format_version\" => 99"))
+                @test_throws ArgumentError load_fusion_category(path)
+                # Pre-metadata archives still decode as column-major packing.
+                untagged = join(filter(l -> !occursin("symbol_format_version",l) && !occursin("symbol_convention",l),split(text,'\n')),'\n')
+                write(meta_file,untagged)
+                E = convention == :column_major_packing ? load_fusion_category(path) : load_fusion_category(path;convention)
+                @test Dict(k=>coerce(v) for (k,v) in F_symbols(E;convention)) == F
+
+                # Low-level exact readers use the explicitly supplied convention.
+                @test TC.load_F_symbols(rank(C),K,joinpath(path,"category_F_symbols");convention) == C.ass
+                @test TC.load_R_symbols(rank(C),K,joinpath(path,"category_R_symbols");convention) == C.braiding
+                for (savefun,data,name) in ((TC.save_F_symbols,F,"F.jl"),(TC.save_R_symbols,R,"R.jl"))
+                    file = joinpath(dir,name)
+                    savefun(C,file;convention)
+                    vectors = include(file)
+                    @test Dict(k=>(K == QQ ? K(v...) : K(v)) for (k,v) in vectors) == data
+                end
+
+                ff,rf = joinpath(dir,"F.csv"),joinpath(dir,"R.csv")
+                numeric_symbols_to_csv(ff,Fn;convention)
+                numeric_symbols_to_csv(rf,Rn;convention)
+                @test startswith(readline(ff),"#") == (convention == :bonderson)
+                Kn = AcbField(128)
+                decoded = TC._load_numeric_fusion_category(Fn,Rn,Kn;convention,check=true)
+                loaded = load_numeric_fusion_category(ff,rf,Kn;check=true)
+                same_matrices(decoded,loaded;numerical=true)
+                @test multiplication_table(load_numeric_fusion_category(ff,Kn;check=true)) == multiplication_table(C)
+                @test keys(numeric_symbols_from_csv(ff,Kn;convention)) == keys(F)
+                if convention == :bonderson
+                    @test_throws ArgumentError numeric_symbols_from_csv(ff;convention=other)
+                    @test_throws ArgumentError load_numeric_fusion_category(ff,rf;convention=other)
+                    # Headerless external Bonderson data can be declared explicitly.
+                    for file in (ff,rf)
+                        write(file,join(readlines(file)[2:end],'\n')*"\n")
+                    end
+                    same_matrices(decoded,load_numeric_fusion_category(ff,rf,Kn;convention,check=true);numerical=true)
+                    # Mixed marked/unmarked files must not be silently combined.
+                    numeric_symbols_to_csv(ff,Fn;convention)
+                    @test_throws ArgumentError load_numeric_fusion_category(ff,rf,Kn)
+                end
+            end
+        end
+    end
+end
+
+@testset "Multiplicity and lazy symbol serialization" begin
+    C = TC.su_3_3_subcategory()
+    # Use a nonsymmetric R block so that a writer/reader convention mismatch
+    # cannot be hidden by the constructor's diagonal braiding matrices.
+    K = base_ring(C)
+    P = matrix(K,2,2,[1,1,0,1])
+    E = basis(Hom(C[2] ⊗ C[2],C[2]))
+    V = TC.gauge_transform(C,Dict((2,2,2)=>[sum(P[i,j]*E[i] for i in 1:2) for j in 1:2]))
+    V.braiding[2,2,2] = inv(P)*TC.r_symbol(C,2,2,2)*P
+    for convention in (:column_major_packing,:bonderson)
+        F,R = F_symbols(V;convention),R_symbols(V;convention)
+        @test TC._fusion_rules_from_symbol_dictionary(F;convention,check=true)[1] == multiplication_table(V)
+        @test TC.dict_to_associator(F;convention) == V.ass
+        @test TC.dict_to_braiding(R;convention) == V.braiding
+        emb = first(complex_embeddings(K))
+        Fn = numeric_F_symbols(V,emb;convention,precision=128)
+        Rn = numeric_R_symbols(V,emb;convention,precision=128)
+        @test all(overlaps(Rn[k],emb(v,128)) for (k,v) in R)
+        @test all(overlaps(Fn[k],emb(v,128)) for (k,v) in F)
+        mktempdir() do dir
+            TC.save_symbols(F,joinpath(dir,"F"),4;convention)
+            TC.save_symbols(R,joinpath(dir,"R");convention)
+            @test TC.load_F_symbols(rank(V),K,joinpath(dir,"F");convention) == V.ass
+            @test TC.load_R_symbols(rank(V),K,joinpath(dir,"R");convention) == V.braiding
+            ff,rf = joinpath(dir,"F.csv"),joinpath(dir,"R.csv")
+            numeric_symbols_to_csv(ff,Fn;convention)
+            numeric_symbols_to_csv(rf,Rn;convention)
+            # CSV stores decimal approximations, not ball radii. Read at
+            # lower precision than the exported coefficients for overlap tests.
+            D = load_numeric_fusion_category(ff,rf,AcbField(64);check=true)
+            @test multiplication_table(D) == multiplication_table(V)
+            DF,DR = F_symbols(D;convention),R_symbols(D;convention)
+            @test all(overlaps(DR[k],v) for (k,v) in Rn)
+            @test all(overlaps(DF[k],v) for (k,v) in Fn)
+        end
+    end
+    ass,braid = deepcopy(V.ass),deepcopy(V.braiding)
+    set_associator!(V,similar(V.ass))
+    set_braiding!(V,similar(V.braiding))
+    set_attribute!(V,:six_j_symbol,(a,b,c,d)->ass[a,b,c,d])
+    set_attribute!(V,:r_symbol,(a,b,c)->braid[a,b,c])
+    @test !isassigned(V.ass,1,1,1,1)
+    @test TC.dict_to_associator(F_symbols(V;convention=:bonderson);convention=:bonderson) == ass
+    @test TC.dict_to_braiding(R_symbols(V;convention=:bonderson);convention=:bonderson) == braid
+end

--- a/test/SixJCategoryTests/SymbolConventions.jl
+++ b/test/SixJCategoryTests/SymbolConventions.jl
@@ -1,0 +1,209 @@
+# The symbol equations are tested independently of the matrix decoders.
+# Reference: P. Bonderson, Non-Abelian Anyons and Interferometry (2007),
+# https://thesis.caltech.edu/2447/02/thesis.pdf, (2.6), (2.54), (2.57)-(2.58),
+# and the multiplicity-free pentagon (2.77).
+module SymbolConventionTests
+using TensorCategories, Oscar, Test
+const TC = TensorCategories
+
+# Multiplicity-free pentagon (Bonderson (2.77)), with admissibility loops
+# selecting the fusion paths for which both factors on the left are defined.
+function scalar_pentagons(cat)
+    fsymb = F_symbols(cat; convention=:bonderson)
+    r = rank(cat)
+    mt = multiplication_table(cat)
+    K = base_ring(cat)
+    getF(v) = fsymb[v]
+    checked = 0
+    for a in 1:r, b in 1:r, c in 1:r, d in 1:r
+        for f in 1:r
+            mt[a,b,f] == 0 && continue
+            for l in 1:r
+                mt[c,d,l] == 0 && continue
+                for g in 1:r
+                    mt[f,c,g] == 0 && continue
+                    for k in 1:r
+                        mt[b,l,k] == 0 && continue
+                        for e in 1:r
+                            mt[g,d,e]*mt[f,l,e]*mt[a,k,e] == 0 && continue
+                            lhs = getF([f,c,d,e,g,l])*getF([a,b,l,e,f,k])
+                            rhs = K(0)
+                            for h in 1:r
+                                mt[b,c,h] == 0 && continue
+                                mt[a,h,g] == 0 && continue
+                                mt[h,d,k] == 0 && continue
+                                rhs += getF([a,b,c,g,f,h]) *
+                                       getF([a,h,d,e,g,k]) *
+                                       getF([b,c,d,k,h,l])
+                            end
+                            @test lhs == rhs
+                            checked += 1
+                        end
+                    end
+                end
+            end
+        end
+    end
+    checked
+end
+
+# Also check equations with a forced-zero left hand side, using the same
+# pentagon identity and admissible external fusion paths.
+function zero_lhs_pentagons(C)
+    n = rank(C)
+    N = multiplication_table(C)
+    F = F_symbols(C;convention=:bonderson)
+    checked = 0
+    for a in 1:n,b in 1:n,c in 1:n,d in 1:n,e in 1:n,f in 1:n,g in 1:n,k in 1:n,l in 1:n
+        N[a,b,f]*N[f,c,g]*N[g,d,e]*N[c,d,l]*N[b,l,k]*N[a,k,e] == 0 && continue
+        N[f,l,e] == 0 || continue
+        rhs = sum((F[[a,b,c,g,f,h]]*F[[a,h,d,e,g,k]]*F[[b,c,d,k,h,l]]
+            for h in 1:n if N[b,c,h]*N[a,h,g]*N[h,d,k] != 0);init=base_ring(C)(0))
+        @test iszero(rhs)
+        checked += 1
+    end
+    checked
+end
+
+# Bonderson (2.57)-(2.58), specialized to multiplicity-free fusion. Both
+# directions are checked. The shorthand (2.78)-(2.79) reverses the ordered
+# R superscripts relative to (2.57)-(2.58); the asymmetric pointed fixture
+# distinguishes these, consistently with the defining R-move (2.54).
+# Inverse R means the inverse of the indicated
+# braiding, not complex conjugation (the bases need not be unitary).
+function scalar_hexagons(C)
+    N = multiplication_table(C)
+    n = rank(C)
+    K = base_ring(C)
+    F = F_symbols(C; convention=:bonderson)
+    R = R_symbols(C; convention=:bonderson)
+    checked = 0
+    for a in 1:n, b in 1:n, c in 1:n, d in 1:n, e in 1:n, g in 1:n
+        N[c,a,e]*N[e,b,d]*N[a,g,d]*N[c,b,g] == 0 && continue
+        lhs = R[[c,a,e]] * F[[a,c,b,d,e,g]] * R[[c,b,g]]
+        lhs_inv = inv(R[[a,c,e]]) * F[[a,c,b,d,e,g]] * inv(R[[b,c,g]])
+        rhs, rhs_inv = K(0), K(0)
+        for f in 1:n
+            N[a,b,f]*N[c,f,d] == 0 && continue
+            rhs += F[[c,a,b,d,e,f]] * R[[c,f,d]] * F[[a,b,c,d,f,g]]
+            rhs_inv += F[[c,a,b,d,e,f]] * inv(R[[f,c,d]]) * F[[a,b,c,d,f,g]]
+        end
+        @test lhs == rhs
+        @test lhs_inv == rhs_inv
+        checked += 2
+    end
+    checked
+end
+
+# Check the definition against actual projection morphisms, including every
+# multiplicity index. This does not call the dictionary-to-matrix decoders.
+function projection_equations(C)
+    n = rank(C)
+    N = multiplication_table(C)
+    H = [basis(Hom(C[a] ⊗ C[b],C[d])) for a in 1:n,b in 1:n,d in 1:n]
+    F = F_symbols(C; convention=:bonderson)
+    R = R_symbols(C; convention=:bonderson)
+    mf = multiplicity(C) == 1
+    for a in 1:n,b in 1:n,c in 1:n,d in 1:n
+        for f in 1:n, ρ in 1:N[b,c,f], σ in 1:N[a,f,d]
+            lhs = H[a,f,d][σ] ∘ (id(C[a]) ⊗ H[b,c,f][ρ]) ∘ associator(C[a],C[b],C[c])
+            rhs = zero_morphism(domain(lhs),codomain(lhs))
+            for e in 1:n, μ in 1:N[a,b,e], ν in 1:N[e,c,d]
+                key = mf ? [a,b,c,d,e,f] : [a,b,c,d,e,μ,ν,f,ρ,σ]
+                rhs += F[key] * (H[e,c,d][ν] ∘ (H[a,b,e][μ] ⊗ id(C[c])))
+            end
+            @test lhs == rhs
+        end
+    end
+    for a in 1:n,b in 1:n,c in 1:n,ν in 1:N[b,a,c]
+        lhs = H[b,a,c][ν] ∘ braiding(C[a],C[b])
+        rhs = zero_morphism(domain(lhs),codomain(lhs))
+        for μ in 1:N[a,b,c]
+            key = mf ? [a,b,c] : [a,b,c,μ,ν]
+            rhs += R[key] * H[a,b,c][μ]
+        end
+        @test lhs == rhs
+    end
+end
+
+@testset "F/R conventions: AnyonWiki Ising category" begin
+    C = anyonwiki(3,1,0,1,1,1,1)
+    old_ass,old_braid = deepcopy(C.ass),deepcopy(C.braiding)
+    D = F_symbols(C)
+    F = F_symbols(C; convention=:bonderson)
+    @test D == F_symbols(C; convention=:column_major_packing)
+    @test D != F
+    @test D[[1,3,3,1,1,3]] == F[[1,3,3,1,3,1]] == 1
+    @test !haskey(D,[1,3,3,1,3,1])
+    # Historical packing cannot be repaired by globally swapping e and f:
+    # for this block the two channel sets agree, but the matrix is asymmetric.
+    z = gen(base_ring(C))
+    s = (z^6-z^2)/2
+    t = -(z^6+z^2)/2
+    @test s != t
+    @test F[[3,3,3,3,1,2]] == D[[3,3,3,3,1,2]] == t
+    @test F[[3,3,3,3,2,1]] == D[[3,3,3,3,2,1]] == s
+    @test scalar_pentagons(C) == 132
+    @test zero_lhs_pentagons(C) == 4
+    @test scalar_hexagons(C) > 0
+    @test R_symbols(C) == R_symbols(C; convention=:bonderson)
+    @test R_symbols(C; convention=:bonderson)[[2,2,1]] == -1 # fermion
+    projection_equations(C)
+    @test C.ass == old_ass && C.braiding == old_braid
+    for f in (F_symbols,R_symbols,numeric_F_symbols,numeric_R_symbols)
+        @test_throws ArgumentError f(C; convention=:unknown)
+    end
+end
+
+# A pointed category with a nontrivial change of binary bases distinguishes
+# c_ab from c_ba: symmetric/diagonal R fixtures cannot do this. For additive
+# C3 and nonzero normalized t(a,b), the projection basis p'_ab=t(a,b)p_ab
+# gives A(a,b,c)=t(b,c)t(a,b+c)/(t(a,b)t(a+b,c)) and
+# R(a,b)=t(b,a)/t(a,b). These are a coboundary and its induced braiding.
+function pointed_fixture()
+    n = 3
+    add(a,b) = mod(a+b-2,n)+1
+    N = [Int(add(a,b)==c) for a in 1:n,b in 1:n,c in 1:n]
+    C = six_j_category(QQ,N,["1","g","g²"])
+    set_one!(C,1)
+    t = QQ[1 1 1; 1 2 3; 1 5 7]
+    for a in 1:n,b in 1:n,c in 1:n
+        d = add(add(a,b),c)
+        C.ass[a,b,c,d][1,1] = t[b,c]*t[a,add(b,c)]/(t[a,b]*t[add(a,b),c])
+    end
+    set_braiding!(C,[N[a,b,c] == 0 ? zero_matrix(QQ,0,0) :
+        matrix(QQ,1,1,[t[b,a]/t[a,b]]) for a in 1:n,b in 1:n,c in 1:n])
+    set_name!(C,"Vec(C3), rescaled binary bases")
+    C
+end
+
+@testset "R direction and multiplicity indices" begin
+    C = pointed_fixture()
+    @test R_symbols(C; convention=:bonderson)[[2,3,1]] == QQ(5)/3
+    @test R_symbols(C; convention=:bonderson)[[3,2,1]] == QQ(3)/5
+    @test scalar_hexagons(C) == 54
+    @test pentagon_axiom(C) && hexagon_axiom(C)
+
+    U = TC.su_3_3_subcategory()
+    K = base_ring(U)
+    E = basis(Hom(U[2] ⊗ U[2],U[2]))
+    P = matrix(K,2,2,[1,1,0,1])
+    newE = [sum(P[i,j]*E[i] for i in 1:2) for j in 1:2]
+    V = TC.gauge_transform(U,Dict((2,2,2)=>newE))
+    B = inv(P)*TC.r_symbol(U,2,2,2)*P
+    V.braiding[2,2,2] = B
+    @test B != transpose(B)
+    @test pentagon_axiom(V) && hexagon_axiom(V)
+    R = R_symbols(V; convention=:bonderson)
+    old = R_symbols(V)
+    @test R[[2,2,2,1,2]] == B[1,2] != B[2,1]
+    @test old[[2,2,2,1,2]] == B[2,1]
+    projection_equations(V)
+    for convention in (:column_major_packing,:bonderson)
+        @test TC.dict_to_associator(F_symbols(V;convention);convention) == V.ass
+        @test TC.dict_to_braiding(R_symbols(V;convention);convention) == V.braiding
+    end
+end
+
+include("SymbolConventionSerialization.jl")
+end # module

--- a/test/full.jl
+++ b/test/full.jl
@@ -45,3 +45,5 @@ include("Anyonwiki/QuickTest.jl")
 include("Anyonwiki/AnyonwikiTest.jl")
 
 #include("CoherentSheaves/ConvolutionCategoryTests.jl")
+
+include("SixJCategoryTests/SymbolConventions.jl")

--- a/test/quick.jl
+++ b/test/quick.jl
@@ -8,3 +8,5 @@ include("VectorSpacesTest/VSTest.jl")
 include("SixJCategoryTests/RingCatTests.jl")
 include("InterfaceTests.jl")
 include("Anyonwiki/QuickTest.jl")
+
+include("SixJCategoryTests/SymbolConventions.jl")


### PR DESCRIPTION
F- and R-symbol dictionaries currently use a historical column-major packing whose keys do not always identify the coefficient's fusion paths. This makes it difficult to use the returned data directly in published pentagon and hexagon equations.

This adds `convention=:bonderson` to exact and numerical F/R symbol extraction and symbol save/load functions. The new dictionaries directly index the coefficients defined in Bonderson's thesis, equations (2.6) and (2.54). The default remains `:column_major_packing`; structural matrices, fusion bases, existing database files, and ordinary dictionary return types are unchanged.

Exact category archives record their format version and convention. Numerical CSV files in the nondefault convention carry a header; historical headerless files and untagged archives keep their existing interpretation. Explicit conventions conflicting with metadata are rejected.

The standalone exact F/R writers also emit loadable coefficient-vector dictionaries (including over QQ); numerical R evaluation now handles QQ through the supplied embedding, as numerical F evaluation already does.

Tests cover the scalar pentagon on AnyonWiki `(3,1,0,1,1,1,1)`, including forced-zero equations, both scalar hexagons, projection identities, asymmetric braiding and multiplicity-two basis changes, numerical evaluation, both file encodings, and lazy matrices. Docstrings specify every index and matrix direction. No Documenter files or database artifacts are changed.

Validation:

- Scalar pentagon equations pass for all 76 rank-at-most-five representatives using `F_symbols(cat; convention=:bonderson)`.
- Default dictionaries agree with the previous implementation on all 279 entries up to rank five and a multiplicity-two category.
- The hexagon tests specialize thesis equations (2.57)–(2.58), consistent with (2.54). The ordered R superscripts in the shorthand equations (2.78)–(2.79) differ; asymmetric braiding fixtures prevent silently confusing those directions.

- Full Julia test suite passed using the existing development environment.
