### PR TITLE
Restore group representation backends

### DIFF
--- a/docs/src/API/Categories.md
+++ b/docs/src/API/Categories.md
@@ -12,7 +12,7 @@ table.
 | Finite sets and maps | `Sets`, `SetObject`, `SetMorphism`, `SetHomSet` | [Finite sets](../Interface/Categories.md#finite-sets) |
 | Finite-dimensional vector spaces | `vector_spaces`, `VectorSpaces`, `VectorSpaceObject`, `VectorSpaceMorphism`, `VSObject`, `VSHomSpace` | [Vector spaces and gradings](../ConcreteExamples/VectorSpaces.md) |
 | Group-graded vector spaces | `graded_vector_spaces`, `twisted_graded_vector_spaces`, `GradedVectorSpaces`, `GVSObject`, `GVSMorphism`, `GVSHomSpace`, `Cocycle`, `cyclic_group_3cocycle`, `unitary_cocycle` | [Vector spaces and gradings](../ConcreteExamples/VectorSpaces.md) |
-| Finite-group representations | `representation_category`, `GroupRepresentationCategory`, `GroupRepresentation`, `GroupRepresentationMorphism`, `GRHomSpace`, `Representation` | [Group representations](../ConcreteExamples/Representations.md) |
+| Finite-group representations | `representation_category`, `rep`, `GroupRepresentationCategory`, `GroupRepresentation`, `GroupRepresentationMorphism`, `GRHomSpace`, `Representation` | [Group representations](../ConcreteExamples/Representations.md) |
 | Equivariant coherent sheaves | `coherent_sheaves`, `convolution_category` | [Equivariant sheaves and convolution](../ConcreteExamples/CoherentSheaves.md) |
 | Generic quantum $\mathfrak{sl}_2$ model | `sl2_representations` | [$\mathfrak{sl}_2$, Verlinde, and dihedral models](../ConcreteExamples/UqSl2.md) |
 

--- a/docs/src/ConcreteExamples/Representations.md
+++ b/docs/src/ConcreteExamples/Representations.md
@@ -64,16 +64,114 @@ Finiteness of $G$ is a hypothesis of this model and is not checked by the
 constructor.
 
 The no-field constructor `representation_category(G)` uses OSCAR's abelian
-closure of `QQ`. Even if the category is mathematically finite, `simples(C)` is
-not supported over every coefficient field. The current backend enumerates over
-finite fields (and handles the trivial group directly); it does not enumerate
-characteristic-zero irreducibles with their Schur-index information.
-Constructing explicit representations and computing their Hom spaces still
-works.
+closure of `QQ`, which is a splitting field for every finite group. Ordinary
+irreducible representations can therefore be enumerated:
 
-For small finite fields, the representation backend can enumerate simples and
-decompose modules. In modular characteristic distinguish composition factors
-from direct-sum summands. See [Splitting](@ref tensor-conventions).
+```@example representations
+D = representation_category(symmetric_group(3))
+int_dim.(simples(D))
+```
+
+Over a nonsplitting characteristic-zero field, the absolutely irreducible
+matrices returned by GAP need not be defined over the requested field. The
+implementation checks their entries before constructing any objects and fails
+rather than silently changing the coefficient field. Explicit representations,
+Hom spaces, and exact tests such as `is_simple(X)` remain available in the
+cases described below.
+
+## Representation algorithms and backends
+
+The functions `simples`, `is_simple`, `composition_factors`,
+`simple_subobjects`, and `decompose` accept a `backend` keyword. The available
+values are:
+
+| Value | Behaviour |
+|:---|:---|
+| `:auto` | use the established default for the coefficient field and operation |
+| `:gap` | use GAP's ordinary representation routines or its finite-field MeatAxe |
+| `:hecke` | use Hecke's matrix-module MeatAxe routines |
+
+For finite fields, `:auto` uses GAP. It supports irreducibility tests, simple
+enumeration, composition factors, and indecomposable decomposition. GAP's
+ordinary routine supplies absolutely irreducible representations in
+characteristic zero. This works directly over the default abelian closure and
+over another field when GAP's chosen matrices can be converted to that field.
+It does not by itself construct the simple objects over an arbitrary
+nonsplitting field; Galois orbits and Schur indices enter that problem.
+
+The Hecke backend works directly with the stored generator matrices. It is
+available over finite fields and for one-generator modules over supported
+infinite exact fields. For several generators over an infinite field, the
+current Hecke algorithm does not provide a dependable backend and the package
+reports this limitation. In a semisimple category, the default implementation
+can compute composition multiplicities from Hom spaces once `simples(C)` is
+available. In modular characteristic, composition factors and indecomposable
+direct summands are distinct; `decompose(X; backend=:hecke)` is therefore not
+used there. GAP's relevant matrix-module operations are documented in
+[gapmanual2026; Chapters 69.5 and 69.7](@cite), and the Hecke matrix-module
+implementation is part of the Nemo/Hecke system described by
+[fieker2017nemo](@cite).
+
+The following rational example has one generator, so the Hecke backend can
+recover the two rational simple modules of $C_3$ from the regular
+representation:
+
+```@example representations
+Cq = representation_category(QQ, cyclic_group(3))
+int_dim.(simples(Cq; backend=:hecke))
+```
+
+## Splitting fields
+
+The predicate `is_split_semisimple(C)` tests both semisimplicity and whether
+the endomorphism algebra of every simple is the coefficient field. Over
+$\mathbb Q$, the implementation instead uses the equivalent ordinary-character
+criterion: all irreducible characters must be rational-valued and have Schur
+index one.
+
+If $m$ is the exponent of $G$, Brauer's splitting theorem states that a field
+containing a primitive $m$-th root of unity is a splitting field for $G$. In
+characteristic $p>0$, only the prime-to-$p$ part of $m$ contributes a
+nontrivial root of unity. The function `splitting_field(C)` constructs the
+splitting field of the corresponding polynomial $x^{m'}-1$ over the current
+exact coefficient field, where $m'=m$ in characteristic zero and $m'$ is the
+prime-to-$p$ part of $m$ in characteristic $p$; compare
+[webb2016representations; Theorem 9.2.7](@cite).
+
+!!! note
+    `splitting_field(C)` returns **a** splitting field for $G$ over the current
+    coefficient field. It does not claim to return a minimal splitting field.
+
+```@example representations
+C2 = representation_category(GF(2), cyclic_group(3))
+L = splitting_field(C2)
+@assert degree(L) == 2
+@assert !is_split_semisimple(C2)
+@assert is_split_semisimple(representation_category(L, cyclic_group(3)))
+L
+```
+
+## Indecomposable representations
+
+The predicate `is_finite_representation_type(C)` records whether there are
+only finitely many indecomposable isomorphism classes. In characteristic zero
+and in nonmodular characteristic this follows from Maschke's theorem. If the
+coefficient field has characteristic $p$ dividing $|G|$, Higman's theorem says
+that the representation type is finite exactly when a Sylow $p$-subgroup of
+$G$ is cyclic [higman1954indecomposable](@cite).
+
+When the category is semisimple, `indecomposables(C)` is the same list as
+`simples(C)`. The installed GAP and Hecke backends do not provide a general
+enumeration of every indecomposable module in the modular finite-type case, so
+the predicate is available there but enumeration is not.
+
+```@example representations
+@assert is_finite_representation_type(
+    representation_category(GF(5), cyclic_group(5)))
+@assert !is_finite_representation_type(
+    representation_category(GF(2), symmetric_group(4)))
+nothing # hide
+```
 
 Semisimplicity, splitting, and the distinction between simple and absolutely
 simple objects follow the conventions of [EGNO; §§4.2 and 4.16](@citet).

--- a/docs/src/ConcreteExamples/Representations.md
+++ b/docs/src/ConcreteExamples/Representations.md
@@ -15,6 +15,8 @@ usual left-action convention after replacing $g$ by $g^{-1}$.
 `representation_category(K,G)` models finite-dimensional representations of a
 finite group over the specified field. Objects store a group homomorphism into
 a matrix group. Morphisms are intertwiners in the row-vector convention.
+The shorter forms `rep(K,G)` and `rep(G)` are aliases for
+`representation_category(K,G)` and `representation_category(G)`.
 Use either `Representation(C,generators,matrices; check=false)` for an existing
 category $C$, or `Representation(G,generators,matrices; check=false)` to infer
 the field and parent category from the matrices. The corresponding overloads

--- a/docs/src/Interface/KaroubianCategories.md
+++ b/docs/src/Interface/KaroubianCategories.md
@@ -115,10 +115,9 @@ Over a finite field, the generic decomposition backend forms
 $A=\operatorname{End}_{\mathcal C}(X)$ and decomposes the regular right
 $A$-module. Projecting $1_A$ onto its indecomposable summands gives primitive
 idempotents in $A$, and their images give the indecomposable summands of $X$.
-The group-representation backend instead applies GAP's
-`MTX.Indecomposition` directly to the representation. Hecke.jl's `ModAlgAss`
-MeatAxe routines provide related irreducibility and composition-series
-algorithms, as discussed in the preceding section.
+Finite-group representations have a specialized implementation; see the
+[representation-category inventory page](@ref representations) for its scope
+and backend choices.
 
 Scalar extension can create new idempotents in endomorphism algebras and hence
 new decompositions of formerly indecomposable objects. This is one reason that

--- a/docs/src/Interface/SimpleObjects.md
+++ b/docs/src/Interface/SimpleObjects.md
@@ -56,22 +56,18 @@ interface. Testing whether an object is simple, finding its composition
 factors or simple subobjects, and enumerating all simple objects are generally
 difficult problems that require algorithms specific to the category and its
 coefficient field. These capabilities are therefore implemented separately.
-For representations of finite groups over finite fields, established modular
-representation algorithms are available; TensorCategories.jl uses GAP's
-irreducible-representation routines and MeatAxe functionality, as illustrated
-below.
+For finite-group representations, these operations are available over many
+coefficient fields; their precise scope and backend selection are documented
+on the [representation-category inventory page](@ref representations).
 
 ## Example: Modular group representations
 
 For a finite group $G$ and a field $k$, finite-dimensional
 $k$-representations form a finite abelian category: they are the
 finite-dimensional modules over the finite-dimensional group algebra $kG$.
-In particular, every such representation has finite length. TensorCategories.jl
-converts the representation below to a GAP module and uses GAP's MeatAxe
-routines `MTX.IsIrreducible` and
-`MTX.CollectedFactors` to test simplicity and compute composition factors; see
-[gapmanual2026; §§69.5 and 69.7](@cite). These algorithms use the action
-matrices of the module, not merely its endomorphism algebra.
+In particular, every such representation has finite length. The example below
+tests simplicity and computes composition factors with the specialized
+finite-group representation implementation.
 
 Let $G=C_5$ and $k=\mathbb F_5$. The matrix
 
@@ -119,18 +115,6 @@ nothing # hide
 
 This example shows why composition factors and direct-sum decompositions need
 separate interfaces. We discuss direct summands next.
-
-!!! note "MeatAxe functionality in Hecke"
-    Hecke.jl provides the matrix-module type `ModAlgAss` together with
-    `meataxe`, `composition_series`, `composition_factors`, and
-    `composition_factors_with_multiplicity` [fieker2017nemo](@cite). These
-    algorithms take modules described by generator matrices; the current Hecke
-    test suite exercises them over finite fields, $\mathbb Q$, and a number
-    field. TensorCategories.jl does not currently use this interface for group
-    representations: its `composition_factors` method converts the
-    representation to a GAP module and calls `MTX.CollectedFactors` directly.
-    The Hecke implementation may therefore provide a broader future backend for
-    the categorical function.
 
 Continue with [idempotents and direct-sum decompositions](@ref
 karoubian-categories).

--- a/docs/src/MyBib.bib
+++ b/docs/src/MyBib.bib
@@ -61,6 +61,16 @@
   doi = {10.1215/S0012-7094-54-02138-9}
 }
 
+@book{webb2016representations,
+  author = {Webb, Peter},
+  title = {A Course in Finite Group Representation Theory},
+  publisher = {Cambridge University Press},
+  address = {Cambridge},
+  year = {2016},
+  doi = {10.1017/CBO9781316677216},
+  url = {https://www-users.cse.umn.edu/~webb/RepBook/RepBookLatex.pdf}
+}
+
 @article{krause2015krull,
   author = {Krause, Henning},
   title = {Krull--Schmidt Categories and Projective Covers},

--- a/src/Examples/GroupRepresentations/GroupRepresentations.jl
+++ b/src/Examples/GroupRepresentations/GroupRepresentations.jl
@@ -36,10 +36,73 @@ is_weak_fusion(C::GroupRepresentationCategory) = is_semisimple(C)
 is_weak_multifusion(C::GroupRepresentationCategory) = is_weak_fusion(C)
 function is_fusion(C::GroupRepresentationCategory)
     get_attribute!(C, :fusion) do
-        is_weak_fusion(C) && all(X -> int_dim(End(X)) == 1, simples(C))
+        is_weak_fusion(C) && is_split_semisimple(C)
     end
 end
-is_split_semisimple(C::GroupRepresentationCategory) = is_fusion(C)
+
+"""
+    is_split_semisimple(C::GroupRepresentationCategory)
+
+Return whether `C` is semisimple and every simple representation is
+absolutely simple over its coefficient field.
+"""
+function is_split_semisimple(C::GroupRepresentationCategory)
+    get_attribute!(C, :split_semisimple) do
+        is_semisimple(C) || return false
+        F = base_ring(C)
+        G = base_group(C)
+        if F isa QQField
+            # Over QQ, split semisimplicity is equivalent to every ordinary
+            # irreducible character being rational-valued with Schur index one.
+            return all(χ -> Oscar.degree_of_character_field(χ) == 1 &&
+                            Oscar.schur_index(χ) == 1,
+                       collect(Oscar.character_table(G)))
+        elseif F isa Oscar.QQAbField || F isa QQBarField
+            return true
+        end
+        all(X -> int_dim(End(X)) == 1, simples(C))
+    end
+end
+
+"""
+    is_finite_representation_type(C::GroupRepresentationCategory)
+
+Return whether `C` has only finitely many isomorphism classes of
+indecomposable objects. In modular characteristic this uses Higman's
+criterion: a Sylow subgroup for the characteristic is cyclic.
+"""
+function is_finite_representation_type(C::GroupRepresentationCategory)
+    is_semisimple(C) && return true
+    p = Int(characteristic(base_ring(C)))
+    Oscar.is_cyclic(Oscar.sylow_subgroup(base_group(C), p)[1])
+end
+
+"""
+    splitting_field(C::GroupRepresentationCategory)
+
+Return a splitting field for the finite-group representations in `C`.
+The returned field contains a primitive root of unity whose order is the
+prime-to-characteristic part of the exponent of the group. By Brauer's
+splitting theorem this is sufficient, but it need not be a minimal splitting
+field.
+"""
+function splitting_field(C::GroupRepresentationCategory)
+    F = base_ring(C)
+    Oscar.is_exact_type(F) || throw(ArgumentError(
+        "splitting_field requires an exact coefficient field"))
+    F isa Oscar.QQAbField && return F
+    F isa QQBarField && return F
+    m = Int(exponent(base_group(C)))
+    p = Int(characteristic(F))
+    if p != 0
+        while m % p == 0
+            m = div(m, p)
+        end
+    end
+    m == 1 && return F
+    Fx, x = polynomial_ring(F, "x"; cached=false)
+    Oscar.splitting_field(x^m - one(Fx))
+end
 
 function Base.hash(C::GroupRepresentationCategory, h::UInt)
     hash((C.group, C.base_ring), h)
@@ -552,60 +615,105 @@ end
 #-------------------------------------------------------------------------
 
 """
-    simples(Rep::GroupRepresentationCategory)
+    simples(Rep::GroupRepresentationCategory; backend=:auto)
 
-Return representatives of simple objects. The current backend supports finite
-coefficient fields and the trivial group. Characteristic-zero enumeration for
-nontrivial groups requires a rational/Schur-index backend and throws an error;
-constructing specified representations and computing Hom spaces are separate
-supported operations.
+Return representatives of simple objects. `backend=:gap` uses GAP's ordinary
+or modular representation routines. `backend=:hecke` obtains the simple
+factors of the regular module with Hecke's matrix-module algorithms. The
+default `:auto` uses GAP and reports when a nonsplit characteristic-zero field
+requires a rational/Schur-index backend.
 """
-function simples(Rep::GroupRepresentationCategory)
-    
-    return get_attribute!(Rep, :simples) do
-        #@show Rep.group
-        grp = base_group(Rep)
-        F = base_ring(Rep)
+function simples(Rep::GroupRepresentationCategory; backend::Symbol=:auto)
+    backend in (:auto, :gap, :hecke) || throw(ArgumentError(
+        "backend must be :auto, :gap, or :hecke"))
+    key = backend === :auto ? :simples : Symbol(:simples_, backend)
+    get_attribute!(Rep, key) do
+        grp, F = base_group(Rep), base_ring(Rep)
+        order(grp) == 1 && return [one(Rep)]
+        backend === :hecke && return first.(_composition_factors_hecke(
+            regular_representation(Rep)))
 
-        if order(grp) == 1 return [one(Rep)] end
-
-        is_finite(F) || throw(ArgumentError(
-            "simple enumeration over this field needs a rational/Schur-index backend; constructing representations and Hom spaces is supported"))
-
-        #gap_field = GAP.Globals.FiniteField(Int(characteristic(F)), degree(F))
-        gap_field = codomain(iso_oscar_gap(F))
-        gap_reps = if is_finite(F) 
-            GAP.Globals.IrreducibleRepresentations(grp.X,gap_field)
-        else
+        gap_field = is_finite(F) ? codomain(iso_oscar_gap(F)) : nothing
+        gap_reps = is_finite(F) ?
+            GAP.Globals.IrreducibleRepresentations(grp.X, gap_field) :
             GAP.Globals.IrreducibleRepresentations(grp.X)
+        try
+            generators = gens(grp)
+            [Representation(Rep, generators,
+                [matrix(F, GAP.Globals.Image(m, g.X)) for g in generators];
+                check=false) for m in gap_reps]
+        catch
+            backend === :gap && rethrow()
+            throw(ArgumentError(
+                "GAP's absolutely irreducible representations are not realizable over this coefficient field; try backend=:hecke for a field-aware matrix-module computation"))
         end
-
-        int_dims = [GAP.Globals.DimensionOfMatrixGroup(GAP.Globals.Range(m)) for m ∈ gap_reps]
-    
-        oscar_reps = [GAPGroupHomomorphism(grp, GL(int_dims[i],F), gap_reps[i]) for i ∈ 1:length(gap_reps)]
-        reps = [GroupRepresentation(Rep,grp,m,F,d) for (m,d) ∈ zip(oscar_reps,int_dims)]
-
-        return reps
-
     end
+end
+
+function _hecke_module(σ::GroupRepresentation)
+    G = base_group(σ)
+    generators = order(G) == 1 ? elements(G) : gens(G)
+    if !is_finite(base_ring(σ)) && length(generators) > 1
+        throw(ArgumentError(
+            "Hecke's matrix-module algorithms are not currently reliable for multiple generators over an infinite field"))
+    end
+    Oscar.Hecke.Amodule([matrix(σ(g)) for g in generators])
+end
+
+function _representation_from_hecke(C::GroupRepresentationCategory, M)
+    Representation(C, gens(base_group(C)), Oscar.Hecke.action_of_gens(M);
+                   check=false)
+end
+
+function _composition_factors_hecke(σ::GroupRepresentation)
+    C = parent(σ)
+    [(_representation_from_hecke(C,M), Int(n)) for (M,n) in
+        Oscar.Hecke.composition_factors_with_multiplicity(_hecke_module(σ))]
+end
+
+"""
+    indecomposables(C::GroupRepresentationCategory; backend=:auto)
+
+Enumerate all indecomposable representations when supported. In a semisimple
+category these are the simple representations. The finite-representation-type
+predicate is available in modular characteristic, but the installed backends
+do not provide a general enumeration there.
+"""
+function indecomposables(C::GroupRepresentationCategory; backend::Symbol=:auto)
+    is_semisimple(C) && return simples(C; backend)
+    is_finite_representation_type(C) || throw(ArgumentError(
+        "the representation category has infinite representation type"))
+    throw(ArgumentError(
+        "enumeration of all indecomposable modular representations is not implemented"))
 end
 
 
 """
-    decompose(σ::GroupRepresentation)
+    decompose(σ::GroupRepresentation; backend=:auto)
 
 Decompose the representation into a direct sum of indecomposable objects.
 Return a list of tuples with indecomposable objects and multiplicities.
 """
-#=  =# function decompose(σ::GroupRepresentation)
+#=  =# function decompose(σ::GroupRepresentation; backend::Symbol=:auto)
+    backend in (:auto, :gap, :hecke) || throw(ArgumentError(
+        "backend must be :auto, :gap, or :hecke"))
     F = base_ring(σ)
     if int_dim(σ) == 0 return [] end
     G = σ.group
 
     if order(G) == 1 return [(one(parent(σ)),int_dim(σ))] end
 
-    is_finite(F) || throw(ArgumentError(
-        "Krull-Schmidt decomposition of these representations currently requires a finite base field"))
+    if backend === :hecke
+        is_semisimple(parent(σ)) || throw(ArgumentError(
+            "Hecke computes composition factors, not indecomposable summands in a nonsemisimple category"))
+        return _composition_factors_hecke(σ)
+    elseif !is_finite(F)
+        backend === :gap && throw(ArgumentError(
+            "GAP's MeatAxe backend requires a finite coefficient field"))
+        is_semisimple(parent(σ)) || throw(ArgumentError(
+            "Krull-Schmidt decomposition over this field is unsupported"))
+        return _semisimple_representation_factors(σ)
+    end
 
     M = to_gap_module(σ,F)
     ret = Object[]
@@ -624,17 +732,28 @@ end
 # end
 
 """
-    composition_factors(σ::GroupRepresentation)
+    composition_factors(σ::GroupRepresentation; backend=:auto)
 
 Return simple composition factors with their Jordan--Hölder multiplicities.
 These are subquotients, not necessarily subobjects or direct summands.
 """
-function composition_factors(σ::GroupRepresentation)
+function composition_factors(σ::GroupRepresentation; backend::Symbol=:auto)
+    backend in (:auto, :gap, :hecke) || throw(ArgumentError(
+        "backend must be :auto, :gap, or :hecke"))
     F = base_ring(σ)
     if int_dim(σ) == 0 return Tuple{GroupRepresentation,Int}[] end
     G = σ.group
 
     if order(G) == 1 return [(one(parent(σ)),int_dim(σ))] end
+
+    backend === :hecke && return _composition_factors_hecke(σ)
+    if !is_finite(F)
+        backend === :gap && throw(ArgumentError(
+            "GAP's MeatAxe backend requires a finite coefficient field"))
+        is_semisimple(parent(σ)) || throw(ArgumentError(
+            "composition factors over this field are unsupported"))
+        return _semisimple_representation_factors(σ)
+    end
 
     M = to_gap_module(σ,F)
     ret = Tuple{GroupRepresentation,Int}[]
@@ -647,19 +766,31 @@ function composition_factors(σ::GroupRepresentation)
     ret
 end
 
+function _semisimple_representation_factors(σ::GroupRepresentation)
+    [(S, div(int_dim(Hom(S,σ)), int_dim(End(S))))
+     for S in simples(parent(σ)) if int_dim(Hom(S,σ)) != 0]
+end
+
 """
     simple_subobjects(σ::GroupRepresentation)
 
 Return the simple isomorphism types in the socle, without multiplicities.
 """
-function simple_subobjects(σ::GroupRepresentation)
-    [S for (S,_) in composition_factors(σ) if int_dim(Hom(S,σ)) != 0]
+function simple_subobjects(σ::GroupRepresentation; backend::Symbol=:auto)
+    [S for (S,_) in composition_factors(σ; backend) if int_dim(Hom(S,σ)) != 0]
 end
 
-function is_simple(σ::GroupRepresentation)
+function is_simple(σ::GroupRepresentation; backend::Symbol=:auto)
+    backend in (:auto, :gap, :hecke) || throw(ArgumentError(
+        "backend must be :auto, :gap, or :hecke"))
     int_dim(σ) == 0 && return false
     int_dim(σ) == 1 && return true
     order(base_group(σ)) == 1 && return false
+    if backend === :hecke
+        return Oscar.Hecke.meataxe(_hecke_module(σ))[1]
+    end
+    backend === :gap && !is_finite(base_ring(σ)) && throw(ArgumentError(
+        "GAP's MeatAxe backend requires a finite coefficient field"))
     if !(base_ring(σ) isa FinField)
         characteristic(base_ring(σ)) == 0 || throw(ArgumentError(
             "irreducibility over this field is unsupported"))
@@ -820,7 +951,7 @@ function induction(ρ::GroupRepresentation, G::Group)
 
     hi = [[inv(g_ji[k][i])*g[k]*transversal[i] for i ∈ 1:length(transversal)] for k ∈ 1:length(g)]
 
-    images = []
+    images = MatElem[]
     d = int_dim(ρ)
     n = length(transversal)*d
     for i ∈ 1:length(g)
@@ -829,7 +960,7 @@ function induction(ρ::GroupRepresentation, G::Group)
         for j ∈ 1:length(transversal)
             m[ (ji[i][j]-1)*d+1:ji[i][j]*d, (j-1)*d+1:j*d] = matrix(ρ(hi[i][j]))
         end
-        images = [images; m]
+        push!(images, m)
     end
     return Representation(G, g, images, check = false)
 end

--- a/src/Examples/GroupRepresentations/GroupRepresentations.jl
+++ b/src/Examples/GroupRepresentations/GroupRepresentations.jl
@@ -119,7 +119,7 @@ int_dim(ρ::GroupRepresentation) = ρ.int_dim
 """
     representation_category(F::Field, G::Group)
 
-Category of finite dimensonal group representations of ``G``.
+Category of finite-dimensional group representations of ``G`` over ``F``.
 """
 function representation_category(F::Field, G::Group)
     return GroupRepresentationCategory(G,F)
@@ -128,6 +128,17 @@ end
 function representation_category(G::Group)
     return representation_category(abelian_closure(QQ)[1], G)
 end
+
+"""
+    rep(F::Field, G::Group)
+    rep(G::Group)
+
+Short aliases for `representation_category(F,G)` and
+`representation_category(G)`, respectively. The one-argument form uses the
+abelian closure of the rational field.
+"""
+rep(F::Field, G::Group) = representation_category(F,G)
+rep(G::Group) = representation_category(G)
 
 function extension_of_scalars(C::GroupRepresentationCategory,L::Field;
                               embedding=_scalar_extension_embedding(base_ring(C),L))

--- a/src/TensorCategories.jl
+++ b/src/TensorCategories.jl
@@ -407,6 +407,7 @@ export rand
 export randomized_pentagon_axiom
 export rational_lift 
 export regular_representation
+export rep
 export Representation 
 export RepresentationCategory 
 export representation_category

--- a/src/TensorCategories.jl
+++ b/src/TensorCategories.jl
@@ -268,7 +268,8 @@ export is_central
 export is_epimorphism
 export is_equivalent
 export is_equivariant
-export is_finite 
+export is_finite
+export is_finite_representation_type
 export is_fusion 
 export is_half_braiding
 export is_irreducible
@@ -466,6 +467,7 @@ export solve_groebner
 export sort_simples_by_dimension! 
 export spherical 
 export split
+export splitting_field
 export split_cyclotomic
 export stalk 
 export stalks

--- a/test/InterfaceTests.jl
+++ b/test/InterfaceTests.jl
@@ -669,6 +669,7 @@ end
     X,inc = kernel(aug)
     @test int_dim(X) == 2 && is_simple(X) && int_dim(End(X)) == 1
     @test is_zero(aug ∘ inc) && int_dim(Hom(U,X)) == 0
+    @test is_split_semisimple(C) && is_fusion(C)
 
     # Character theory gives std tensor std = 1 + sign + std, so Schur's
     # lemma gives a three-dimensional endomorphism algebra.
@@ -682,9 +683,28 @@ end
     D = representation_category(QQ,H)
     Y = Representation(D,gens(H),[matrix(QQ,2,2,[0,1,-1,-1])])
     @test int_dim(End(Y)) == 2 && is_simple(Y)
+    @test !is_split_semisimple(D) && !is_fusion(D)
+    @test sort(int_dim.(simples(D;backend=:hecke))) == [1,2]
+    @test sort([(int_dim(S),m) for (S,m) in
+                composition_factors(regular_representation(D);backend=:hecke)]) ==
+          [(1,1),(2,1)]
+    L = splitting_field(D)
+    @test degree(L) == 2
     # Enumeration needs a rational/Schur-index-aware backend; importing GAP's
     # absolutely irreducible list over a different field would be incorrect.
     @test_throws ArgumentError simples(C)
+    @test_throws ArgumentError is_simple(X;backend=:gap)
+
+    # The no-field constructor uses the abelian closure, where GAP's ordinary
+    # irreducibles give all simples. This restores the established
+    # characteristic-zero path without relying on an undocumented rational
+    # irreducible-module interface.
+    A = representation_category(G)
+    @test int_dim.(simples(A)) == [1,1,2]
+    reg = regular_representation(A)
+    @test int_dim(reg) == 6
+    @test sort([(int_dim(S),m) for (S,m) in composition_factors(reg)]) ==
+          [(1,1),(1,1),(2,2)]
 end
 
 function audit_jordan_representation(C, n)
@@ -717,8 +737,12 @@ end
     @test is_simple(J1)
     # J2 is a nonsplit length-two extension with only one factor type.
     @test !is_simple(J2) && !is_simple(J1 ⊕ J1)
+    @test !is_simple(J2;backend=:hecke)
     cf = composition_factors(J2)
     @test length(cf) == 1 && cf[1][2] == 2 && int_dim(cf[1][1]) == 1
+    cfh = composition_factors(J2;backend=:hecke)
+    @test length(cfh) == 1 && cfh[1][2] == 2 && int_dim(cfh[1][1]) == 1
+    @test_throws ArgumentError decompose(J2;backend=:hecke)
     soc = simple_subobjects(J2)
     @test length(soc) == 1 && int_dim(only(soc)) == 1
 
@@ -738,6 +762,26 @@ end
     S = only(simple_subobjects(Y))
     # The sign socle embeds, while the trivial head is only a quotient.
     @test int_dim(Hom(S,Y)) == 1 && int_dim(Hom(Y,S)) == 0
+end
+
+@testset "Splitting fields and representation type" begin
+    H = cyclic_group(3)
+    C = representation_category(GF(2),H)
+    L = splitting_field(C)
+    @test degree(L) == 2
+    @test !is_split_semisimple(C)
+    @test is_split_semisimple(representation_category(L,H))
+    @test is_finite_representation_type(C)
+    @test sort(int_dim.(indecomposables(C))) == [1,2]
+
+    M = representation_category(GF(5),cyclic_group(5))
+    @test is_finite_representation_type(M)
+    @test splitting_field(M) == GF(5)
+    @test_throws ArgumentError indecomposables(M)
+
+    I = representation_category(GF(2),symmetric_group(4))
+    @test !is_finite_representation_type(I)
+    @test_throws ArgumentError indecomposables(I)
 end
 
 # Finite-dimensional vector spaces are simple exactly in integer dimension

--- a/test/InterfaceTests.jl
+++ b/test/InterfaceTests.jl
@@ -700,6 +700,8 @@ end
     # characteristic-zero path without relying on an undocumented rational
     # irreducible-module interface.
     A = representation_category(G)
+    @test rep(G) == A
+    @test rep(QQ,G) == C
     @test int_dim.(simples(A)) == [1,1,2]
     reg = regular_representation(A)
     @test int_dim(reg) == 6


### PR DESCRIPTION
The v0.6 infinite-field simple-enumeration path requested GAP's cyclotomic absolutely irreducible representations and wrapped them as objects over whichever coefficient field the category declared. A later finite-field guard prevented that mismatch, but it also disabled the valid default characteristic-zero path over the abelian closure of the rationals.

This PR restores that path while converting every matrix into the declared coefficient field and rejecting incompatible realizations. It also:

- adds explicit GAP and Hecke backend selection for simple enumeration, simplicity tests, composition factors, simple subobjects, and decomposition;
- supports rational one-generator modules through Hecke and semisimple multiplicities through Hom spaces;
- adds split-semisimplicity tests, Brauer splitting fields, finite representation type, and indecomposable enumeration where the available backends support it;
- corrects the v0.6 simplicity and factor-multiplicity behavior;
- fixes matrix collection in induction and regular representations;
- adds `rep(K,G)` and `rep(G)` aliases while retaining the abelian closure of the rationals as the one-argument default; and
- consolidates the supported scope and backend details in the representation-category documentation.

Validated with the full interface test file, the complete v0.6 group-representation test file, and the strict documentation build.
