### PR TITLE
Simplify test matrix

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -1,6 +1,8 @@
 name: Runtests
 on:
   push:
+    branches:
+      - master
   pull_request:
   workflow_dispatch:
 
@@ -15,11 +17,11 @@ jobs:
     env:
       TENSORCATEGORIES_TEST_SUITE: ${{ github.event_name == 'workflow_dispatch' && 'full' || 'quick' }}
     strategy:
-      # Run expensive full-suite coverage once; keep the quick compatibility matrix.
+      # Pull requests test supported Julia versions on Linux. A master build
+      # adds one macOS integration check. Manual runs execute the full suite
+      # once on Linux.
       matrix:
-        julia-version: ${{ fromJSON(github.event_name == 'workflow_dispatch' && '["1.12"]' || '["1.11", "1.12"]') }}
-        julia-arch: [x64]
-        os: ${{ fromJSON(github.event_name == 'workflow_dispatch' && '["ubuntu-latest"]' || '["ubuntu-latest", "macOS-latest"]') }}
+        include: ${{ fromJSON(github.event_name == 'workflow_dispatch' && '[{"os":"ubuntu-latest","julia-version":"1.12"}]' || github.event_name == 'push' && '[{"os":"ubuntu-latest","julia-version":"1.11"},{"os":"ubuntu-latest","julia-version":"1.12"},{"os":"macos-latest","julia-version":"1.12"}]' || '[{"os":"ubuntu-latest","julia-version":"1.11"},{"os":"ubuntu-latest","julia-version":"1.12"}]') }}
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest


### PR DESCRIPTION
Pull requests currently run the same quick test matrix for both the branch push and the pull-request event, and repeat both supported Julia versions on macOS. This duplicates coverage without materially improving validation of TensorCategories.jl.

This PR:

- runs pull-request tests on Ubuntu with Julia 1.11 and 1.12;
- adds one Julia 1.12 macOS integration check after changes reach `master`;
- restricts automatic push runs to `master`, eliminating duplicate feature-branch runs; and
- retains the manual full suite as one Julia 1.12 Ubuntu job with coverage.
