### PR TITLE
Harden and document pivotal transport during skeletonization

### DIFF
--- a/docs/src/F-symbols/SkeletalFusion.md
+++ b/docs/src/F-symbols/SkeletalFusion.md
@@ -373,7 +373,7 @@ The order of $a$ and $b$ matters. The inverse of $B^{ab}_d$ represents the
 inverse map from $b\otimes a$ to $a\otimes b$; it is not generally
 $B^{ba}_d$.
 
-### Pivotal coefficients
+### [Pivotal coefficients](@id pivotal-coefficients)
 
 A pivotal structure is a monoidal natural isomorphism
 
@@ -420,6 +420,39 @@ additional equality of the left and right pivotal traces and can be checked
 with `is_spherical(C; check=true)`. Since a $P$-symbol dictionary has one
 scalar per simple object rather than matrix entries indexed by fusion paths,
 `P_symbols` has no `convention` keyword.
+
+When `skeletonize(C)` constructs a skeletal model from a concrete category,
+the ordered simple representatives and the bases of
+$\operatorname{Hom}(S_i\otimes S_j,S_k)$ determine the skeletal associator,
+braiding, and duality. The same choices must therefore be used when the
+pivotal structure is transported. Let $S_i$ be the source representative,
+let $\widehat S_i$ be the corresponding skeletal simple, and let
+$j^{(0)}_{\widehat S_i}=\operatorname{id}_{\widehat S_i}$ denote the reference
+double-dual identification before its pivotal coefficient is changed. The
+transported coefficient is
+
+```math
+\label{eq:skeletal-pivotal-transport}
+P_i=
+\frac{\operatorname{Tr}_{L}(j_{S_i})}
+     {\operatorname{Tr}_{L}(j^{(0)}_{\widehat S_i})}.
+```
+
+This trace ratio is the coordinate of the transported map in the
+one-dimensional split-simple double-dual Hom space. Its denominator is
+nonzero: in a semisimple tensor category the trace of an isomorphism from a
+simple object to its double dual is nonzero
+[EGNO; Proposition 4.8.4](@cite). This remains true in positive
+characteristic under the split semisimple hypotheses required by
+`skeletonize`. With ball-valued coefficients, an enclosure containing zero
+means that the chosen working precision does not resolve this nonzero trace;
+skeletonization then asks for higher precision instead of retaining default
+coefficients.
+
+The values $P_i$ are coordinates in the resulting skeletal gauge. Changing
+the multiplicity-space bases can change them, even though the transported
+pivotal category remains equivalent. In particular, an all-one pivotal vector
+is a statement about a chosen presentation, not an invariant of the category.
 
 ### [Unit normalization](@id unit-normalization)
 

--- a/docs/src/F-symbols/WorkedExamples.md
+++ b/docs/src/F-symbols/WorkedExamples.md
@@ -157,10 +157,13 @@ available for computations on graded vectors and matrices.
 The related function `six_j_symbols(V)` computes only the array of associator
 blocks in such chosen bases. The generic `skeletonize(V)` packages these blocks
 with the fusion rules and unit, transports a braiding when one is present, and
-attempts to transport the pivotal or spherical structure. If that transport is
-not available, the skeletal initializer's coefficients $P_i=1$ remain in
-place; use `is_pivotal(C; check=true)` before treating them as a pivotal
-structure.
+transports the pivotal or spherical structure in the same multiplicity-space
+bases. The [pivotal-coefficient discussion](@ref pivotal-coefficients)
+gives the precise trace-coordinate formula. If the required pivotal traces
+cannot be evaluated, or a numerical enclosure does not resolve their
+nonvanishing, skeletonization reports an error rather than retaining the
+initializer's default coefficients. Pass `check=true` to `skeletonize` for
+explicit pentagon, hexagon, pivotal, and spherical verification.
 
 For `GradedVectorSpaces` there is also a specialized direct conversion
 `six_j_category(V)`. It reads the group multiplication, cocycle associator, and

--- a/docs/src/Interface/BasicConstructions.md
+++ b/docs/src/Interface/BasicConstructions.md
@@ -134,7 +134,11 @@ skeletal `SixJCategory` input. It does not return every subcategory generated
 by a single simple object.
 
 Skeletonization changes the presentation of a supported split semisimple
-category; it does not adjoin new half-braidings. The
+category; it does not adjoin new half-braidings. Its associator, braiding, and
+pivotal coefficients are expressed using one shared ordered system of simple
+representatives and multiplicity-space bases. Thus these data describe one
+skeletal gauge; the individual pivotal coefficients need not remain unchanged
+under another choice of bases. The
 [skeletal-model chapter](@ref skeletal-fusion) describes the resulting
 coordinates, while the [Drinfeld-center chapter](@ref center) describes the
 different construction performed by `center(C)`.

--- a/src/TensorCategoryFramework/Skeletonization.jl
+++ b/src/TensorCategoryFramework/Skeletonization.jl
@@ -6,18 +6,70 @@ function _require_split_semisimple_coordinates(C::Category, operation::String)
         "$operation requires split simple endomorphism rings"))
 end
 
-function skeletonize(C::Category, names::Vector{String} = simples_names(C))
-    six_j_category(C, names)
+function _check_skeletal_structure(C::SixJCategory, spherical::Bool)
+    pentagon_axiom(C) || throw(ArgumentError(
+        "the transported associator does not satisfy the pentagon equation"))
+    if is_braided(C)
+        hexagon_axiom(C) || throw(ArgumentError(
+            "the transported braiding does not satisfy the hexagon equations"))
+    end
+    is_pivotal(C;check=true) || throw(ArgumentError(
+        "the transported pivotal structure is not monoidal"))
+    if spherical
+        is_spherical(C;check=true) || throw(ArgumentError(
+            "the transported pivotal structure is not spherical"))
+    end
+    C
 end
 
-function six_j_category(C::Category, names::Vector{String} = simples_names(C))
-    F = six_j_category(C, simples(C), names)
+function _require_resolved_nonzero_dimension(d, i::Int, source::String)
+    if !Oscar.is_exact_type(typeof(d)) && applicable(Oscar.contains_zero,d)
+        Oscar.contains_zero(d) && throw(ArgumentError(
+            "$source dimension of simple $i contains zero at the working precision; " *
+            "increase the precision before skeletonization"))
+    elseif iszero(d)
+        throw(ArgumentError(
+            "$source dimension of simple $i is zero; this contradicts the " *
+            "split semisimple pivotal hypotheses of skeletonization"))
+    end
+    d
+end
+
+function _skeletal_pivotal_coefficients(C::Category, S::Vector{<:Object},
+                                         skel_C::SixJCategory)
+    source_dims = try
+        dim.(S)
+    catch e
+        e isa InterruptException && rethrow()
+        throw(ArgumentError(
+            "skeletonization could not evaluate the source pivotal structure: " *
+            sprint(showerror,e)))
+    end
+    skeletal_dims = dim.(simples(skel_C))
+    for i in eachindex(S)
+        _require_resolved_nonzero_dimension(source_dims[i],i,"source pivotal")
+        _require_resolved_nonzero_dimension(skeletal_dims[i],i,"reference skeletal")
+    end
+    source_dims ./ skeletal_dims
+end
+
+function skeletonize(C::Category, names::Vector{String} = simples_names(C);
+                     check::Bool=false)
+    six_j_category(C, names;check)
+end
+
+function six_j_category(C::Category, names::Vector{String} = simples_names(C);
+                        check::Bool=false)
+    F = six_j_category(C, simples(C), names;check)
     set_name!(F, "Skeletonization of $C")
     return F
 end
 
-function six_j_category(C::Category, S::Vector{<:Object}, names::Vector{String} = simples_names(parent(S[1])))
+function six_j_category(C::Category, S::Vector{<:Object},
+                        names::Vector{String} = simples_names(parent(S[1]));
+                        check::Bool=false)
     if C isa SixJCategory
+        check && _check_skeletal_structure(C,is_spherical(C))
         return C
     end
     is_ring(C) || throw(ArgumentError(
@@ -29,7 +81,8 @@ function six_j_category(C::Category, S::Vector{<:Object}, names::Vector{String} 
     F = base_ring(C)
     source_is_spherical = try
         is_spherical(C)
-    catch
+    catch e
+        e isa InterruptException && rethrow()
         false
     end
 
@@ -62,20 +115,17 @@ function six_j_category(C::Category, S::Vector{<:Object}, names::Vector{String} 
 
     set_associator!(skel_C, ass)
 
-    # if multiplicity(C) > 1
-    #     @warn "6j-Symbols might be wrong since multiplicity is greater than one"
-    # end
-    # Try to set spherical
-    try 
-        set_pivotal!(skel_C,[F(1) for s ∈ S])
-        sp = [dim(S[i]) * inv(dim(skel_C[i])) for i ∈ 1:length(S)]
-        if source_is_spherical
-            set_spherical!(skel_C,sp)
-        else
-            set_pivotal!(skel_C,sp)
-        end
-    catch e 
-        print(e.msg)
+    # The trace of an isomorphism from a split simple to its double dual is
+    # nonzero in a semisimple tensor category (EGNO, Proposition 4.8.4).
+    # Hence traces give faithful coordinates on these one-dimensional Hom
+    # spaces, including in positive characteristic.  The reference traces
+    # below use the skeletal duality determined by the same `homs` bases as
+    # the F- and R-symbols.
+    sp = _skeletal_pivotal_coefficients(C,S,skel_C)
+    if source_is_spherical
+        set_spherical!(skel_C,sp)
+    else
+        set_pivotal!(skel_C,sp)
     end
 
     if is_braided(C)
@@ -86,6 +136,8 @@ function six_j_category(C::Category, S::Vector{<:Object}, names::Vector{String} 
         skel_C.embedding = complex_embedding_of_base_ring(C)
     catch
     end
+
+    check && _check_skeletal_structure(skel_C,source_is_spherical)
 
     return skel_C
 end

--- a/test/Anyonwiki/AnyonwikiTest.jl
+++ b/test/Anyonwiki/AnyonwikiTest.jl
@@ -41,6 +41,16 @@
     Zskel = six_j_category(Zsplit)
     @test multiplication_table(Zskel) == multiplication_table(Zsplit)
     @test pentagon_axiom(Zskel)
+    @test is_pivotal(Zskel;check=true)
+    @test is_spherical(Zskel;check=true)
+
+    # A second associator for the same rank-three fusion ring must use the
+    # identical simple order for its fusion bases and pivotal coordinates.
+    C2 = anyonwiki(3,1,0,2,3,0,1)
+    Z2split, = split(center(C2))
+    Z2skel = six_j_category(Z2split)
+    @test is_pivotal(Z2skel;check=true)
+    @test is_spherical(Z2skel;check=true)
 end
 
 # Scalar conversion preserves the exact polynomial pentagon relations. QQBar

--- a/test/SixJCategoryTests/Examples.jl
+++ b/test/SixJCategoryTests/Examples.jl
@@ -131,6 +131,29 @@ end
     @test U.pivotal == [QQ(2)]
 end
 
+# EGNO Proposition 4.8.4 makes the pivotal trace a nonzero coordinate on the
+# double-dual Hom space of a split simple. Skeletonization uses that coordinate
+# in the same fusion bases as its associator and braiding.
+@testset "Pivotal transport under skeletonization" begin
+    G = cyclic_group(3)
+
+    K,z = cyclotomic_field(3)
+    C = graded_vector_spaces(K,G)
+    g = first(gens(G))
+    C.spherical = Dict(g^i => z^i for i in 0:2)
+    D = skeletonize(C;check=true)
+    @test D.pivotal == [C.spherical[x] for x in elements(G)]
+    @test is_pivotal(D;check=true) && !is_spherical(D;check=true)
+
+    F = GF(7)
+    E = graded_vector_spaces(F,G)
+    E.spherical = Dict(g^i => F(2)^i for i in 0:2)
+    H = skeletonize(E;check=true)
+    @test H.pivotal == [E.spherical[x] for x in elements(G)]
+    @test all(!iszero,dim.(simples(H)))
+    @test is_pivotal(H;check=true) && !is_spherical(H;check=true)
+end
+
 # EGNO Section 4.6: the Deligne square of pointed Vec_C2 has componentwise
 # strict associator. Lazy symbols must survive construction and checking.
 @testset "Lazy associators in a pointed Deligne product" begin


### PR DESCRIPTION
Generic skeletonization transports pivotal coefficients through the ratio of the source pivotal trace and the reference skeletal trace. This formula is valid in the supported split semisimple setting: EGNO Proposition 4.8.4 makes both traces nonzero, including in positive characteristic. The previously suspected positive-characteristic `0/0` case therefore cannot occur in this setting.

The actual defect was the broad `try`/`catch` around this computation. An implementation or numerical failure could silently leave the skeletal initializer's all-one coefficients in place, although they had not been shown to represent the source pivotal structure.

This PR removes that fallback, reports an actual zero or a numerically unresolved enclosure clearly, and adds `check=true` for optional pentagon, hexagon, pivotal, and spherical verification. The manual now records the trace-coordinate formula, its hypotheses, and its dependence on the skeletal gauge.

Tests cover nontrivial pivotal structures in characteristic zero and characteristic seven, together with representative exact AnyonWiki center computations.

Closes #80.
